### PR TITLE
改进脚本和工作流

### DIFF
--- a/.github/workflows/UpdateTranslations.yaml
+++ b/.github/workflows/UpdateTranslations.yaml
@@ -1,0 +1,41 @@
+name: Update Translations
+
+on:
+  workflow_dispatch:
+
+jobs:
+  Update-Translations:
+    name: Update translation from Crowdin
+    if: github.repository == 'nvdacn/zh_CN_Translation'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout ${{ github.repository }} repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        uses: ./.github/workflows/InstallDependencies
+      - name: Configure environment
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $CrowdinToken = "${{ secrets.NVDA_CROWDIN }}"
+          $CrowdinToken | Out-File -FilePath ~/.nvda_crowdin -Encoding ascii
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+        if: success()
+      - name: Process Translations
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+        if: success()
+      - name: Commit & Push
+        shell: pwsh
+        run: |
+          git diff --cached --quiet
+          if ($LASTEXITCODE -ne 0) {
+              git commit -m "更新翻译（从 Crowdin）"
+              git push origin ${{ github.ref_name }}
+          } else {
+              Write-Host "No changes to commit, skipping commit and push."
+          }

--- a/.github/workflows/UpdateTranslations.yaml
+++ b/.github/workflows/UpdateTranslations.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   Update-Translations:
     name: Update translations
-    # if: github.repository == 'nvdacn/zh_CN_Translation'
+    if: github.repository == 'nvdacn/zh_CN_Translation'
     runs-on: windows-latest
     steps:
       - name: Checkout ${{ github.repository }} repository

--- a/.github/workflows/UpdateTranslations.yaml
+++ b/.github/workflows/UpdateTranslations.yaml
@@ -1,18 +1,20 @@
-name: Update Translations
+name: Update Translations from Crowdin
 
 on:
   workflow_dispatch:
 
 jobs:
   Update-Translations:
-    name: Update translation from Crowdin
-    if: github.repository == 'nvdacn/zh_CN_Translation'
+    name: Update translations
+    # if: github.repository == 'nvdacn/zh_CN_Translation'
     runs-on: windows-latest
     steps:
       - name: Checkout ${{ github.repository }} repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # ref: Uploads
+          ref: main
       - name: Install dependencies
         uses: ./.github/workflows/InstallDependencies
       - name: Configure environment
@@ -24,18 +26,31 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
         if: success()
-      - name: Process Translations
-        shell: pwsh
+      - name: Update Translations
         run: |
-          $ErrorActionPreference = 'Stop'
-        if: success()
+          ${{ github.workspace }}/L10nUtilTools.bat DLA
+          git add --update Translation
       - name: Commit & Push
+        id: check-changes
         shell: pwsh
         run: |
           git diff --cached --quiet
           if ($LASTEXITCODE -ne 0) {
               git commit -m "更新翻译（从 Crowdin）"
-              git push origin ${{ github.ref_name }}
+              git push origin
+              echo "has_changes=true" >> $env:GITHUB_OUTPUT
           } else {
               Write-Host "No changes to commit, skipping commit and push."
+              echo "has_changes=false" >> $env:GITHUB_OUTPUT
           }
+      - name: Manually trigger build workflow
+        if: steps.check-changes.outputs.has_changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build.yaml',
+              ref: 'main'
+            });

--- a/.github/workflows/UpdateTranslations.yaml
+++ b/.github/workflows/UpdateTranslations.yaml
@@ -13,8 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # ref: Uploads
-          ref: main
+          ref: Uploads
       - name: Install dependencies
         uses: ./.github/workflows/InstallDependencies
       - name: Configure environment
@@ -52,5 +51,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'build.yaml',
-              ref: 'main'
+              ref: 'Uploads'
             });

--- a/.github/workflows/Upload.yaml
+++ b/.github/workflows/Upload.yaml
@@ -65,8 +65,6 @@ jobs:
                   if (Test-Path $FilePath) {
                       Write-Host "Uploading $file to Crowdin..."
                       & cmd /c "$L10nUtil UP_$baseName"
-                      Remove-Item $file -Force -ErrorAction SilentlyContinue
-                      Write-Host "Removed Uploaded file: $file"
                       Start-Sleep -Seconds 5
                       Write-Host "Downloading updated $file from Crowdin..."
                       & cmd /c "$L10nUtil DL_$baseName"
@@ -83,8 +81,21 @@ jobs:
         run: |
           git diff --cached --quiet
           if ($LASTEXITCODE -ne 0) {
-              git commit -m "更新翻译（从 Crowdin）"
+              git commit -m "更新已上传的翻译文件（从 Crowdin）"
               git push origin ${{ github.ref_name }}
+              echo "has_changes=true" >> $env:GITHUB_OUTPUT
           } else {
               Write-Host "No changes to commit, skipping commit and push."
+              echo "has_changes=false" >> $env:GITHUB_OUTPUT
           }
+      - name: Manually trigger build workflow
+        if: steps.check-changes.outputs.has_changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build.yaml',
+              ref: 'Uploads'
+            });

--- a/L10nUtilTools.bat
+++ b/L10nUtilTools.bat
@@ -252,6 +252,9 @@ if not %errorlevel% equ 0 (
   Git restore "%GitAddPath%/%FileName%"
   exit /b %errorlevel%
 )
+if /I %Type%==LC_MESSAGES (
+powershell -ExecutionPolicy Bypass -File "%~dp0Tools\CheckPo.ps1"
+)
 if /I %Action%==DownloadAndCommit (goto Commit)
 exit /b %errorlevel%
 

--- a/L10nUtilTools.bat
+++ b/L10nUtilTools.bat
@@ -268,8 +268,13 @@ if /I %Type%==All (
   set CommitMSG=更新 %FileName%（从 Crowdin）
 )
 git add %AddFileList%
-git commit -m "%CommitMSG%"
-exit /b %errorlevel%
+git diff --cached --quiet
+if %errorlevel% neq 0 (
+  git commit -m "%CommitMSG%"
+) else (
+  echo No changes to commit, skipping commit.
+)
+exit /b 0
 
 Rem 提取之前翻译的 xliff 文件用于上传时比较差异  
 :ReadyUpload

--- a/L10nUtilTools.bat
+++ b/L10nUtilTools.bat
@@ -233,7 +233,7 @@ Rem **A 系列命令：通过循环调用另一个L10nUtilTools.bat来分别处�
 :All
 for %%i in (L C U) do (
   cmd /C "%~dp0L10nUtilTools" %Parameter%%%i
-  if not !errorlevel! equ 0 (
+  if !errorlevel! neq 0 (
     echo Error: Command %Parameter%%%i failed with exit code !errorlevel!.
     exit /b !errorlevel!
   )
@@ -247,7 +247,7 @@ Rem 从 Crowdin 下载已翻译的文件
 set DownloadFilename=%TranslationPath%\%FileName%
 IF EXIST "%DownloadFilename%" (del /f /q "%DownloadFilename%")
 %L10nUtil% downloadTranslationFile zh-CN "%FileName%" "%DownloadFilename%"
-if not %errorlevel% equ 0 (
+if %errorlevel% neq 0 (
   echo Error: %FileName% download failed with exit code %errorlevel%.
   Git restore "%GitAddPath%/%FileName%"
   exit /b %errorlevel%

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@
 ### beta 开发周期的翻译
 
 可在  `Uploads` 分支翻译 beta 开发周期的所有翻译。具体注意事项，请参看[自动上传翻译][1]章节。
-beta 开发周期的界面消息和文档的翻译字符串可在本地通过 `L10nUtilTools.bat` 的相关命令从 Crowdin 下载。具体使用方法和注意事项，请参看[L10nUtilTools.bat 的使用说明][2]章节。
+beta 开发周期的界面消息和文档的翻译字符串可手动运行 [Update Translations from Crowdin 工作流](https://github.com/nvdacn/zh_CN_Translation/actions/workflows/UpdateTranslations.yaml)进行更新，或在本地通过 `L10nUtilTools.bat` 的相关命令更新。
+`L10nUtilTools.bat` 的具体使用方法和注意事项，请参看[L10nUtilTools.bat 的使用说明][2]章节。
 
 ### 自动上传翻译
 

--- a/Tools/CheckPo.ps1
+++ b/Tools/CheckPo.ps1
@@ -1,19 +1,17 @@
-# 检查nvda.po文件的差异，如果只修改了日期行则还原
+# 检查 nvda.po 文件的差异，如果只修改了 `POT-Creation-Date` 和 `PO-Revision-Date` 行则还原  
 $filePath = "Translation/LC_MESSAGES/nvda.po"
 
-# 获取文件的git diff输出（紧凑模式，不显示上下文）
+# 获取文件的 git diff 输出  
 $diffOutput = git diff --unified=0 $filePath
 
-# 初始化标志位：假设只有日期修改
+# 初始化变量  
 $onlyDateChanges = $true
 $datePattern1 = '^[-+]"POT-Creation-Date:'
 $datePattern2 = '^[-+]"PO-Revision-Date:'
 
-# 逐行分析diff输出
+# 逐行分析 diff 输出  
 foreach ($line in $diffOutput -split "`n") {
-    # 检查实际的内容修改行（以+/-开头）
     if (($line.StartsWith("+") -or $line.StartsWith("-")) -and (-not $line.StartsWith("+++")) -and (-not $line.StartsWith("---"))) {
-        # 如果发现非日期行的修改
         if (-not ($line -match $datePattern1) -and -not ($line -match $datePattern2)) {
             $onlyDateChanges = $false
             break
@@ -21,7 +19,7 @@ foreach ($line in $diffOutput -split "`n") {
     }
 }
 
-# 根据检查结果执行操作
+# 根据检查结果执行操作  
 if ($onlyDateChanges) {
     Write-Host "Detected only date line modifications. Reverting file..."
     Git restore $filePath

--- a/Tools/CheckPo.ps1
+++ b/Tools/CheckPo.ps1
@@ -1,0 +1,31 @@
+# 检查nvda.po文件的差异，如果只修改了日期行则还原
+$filePath = "Translation/LC_MESSAGES/nvda.po"
+
+# 获取文件的git diff输出（紧凑模式，不显示上下文）
+$diffOutput = git diff --unified=0 $filePath
+
+# 初始化标志位：假设只有日期修改
+$onlyDateChanges = $true
+$datePattern1 = '^[-+]"POT-Creation-Date:'
+$datePattern2 = '^[-+]"PO-Revision-Date:'
+
+# 逐行分析diff输出
+foreach ($line in $diffOutput -split "`n") {
+    # 检查实际的内容修改行（以+/-开头）
+    if (($line.StartsWith("+") -or $line.StartsWith("-")) -and (-not $line.StartsWith("+++")) -and (-not $line.StartsWith("---"))) {
+        # 如果发现非日期行的修改
+        if (-not ($line -match $datePattern1) -and -not ($line -match $datePattern2)) {
+            $onlyDateChanges = $false
+            break
+        }
+    }
+}
+
+# 根据检查结果执行操作
+if ($onlyDateChanges) {
+    Write-Host "Detected only date line modifications. Reverting file..."
+    Git restore $filePath
+} else {
+    Write-Host "Substantial changes detected. Keeping modifications."
+}
+Exit


### PR DESCRIPTION
主要改进包括：

- 添加了 CheckPo.ps1 脚本，用于在下载 nvda.po 后检查 nvda.po 文件的差异，如果只修改了 `POT-Creation-Date` 和 `PO-Revision-Date` 行则还原该文件，避免产生无用提交。
- 添加了 UpdateTranslations.yaml 工作流，用于手动从 Crowdin 下载翻译。
- 改进了 Upload.yaml 工作流的默认提交消息，并在有更改推送回存储库时，触发 build.yaml 工作流。
- 其他问题修复。
