### PR TITLE
修复了文档中的若干错别字

### DIFF
--- a/Translation/LC_MESSAGES/nvda.po
+++ b/Translation/LC_MESSAGES/nvda.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: nvda\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-22 01:49+0000\n"
-"PO-Revision-Date: 2025-08-22 01:58\n"
+"PO-Revision-Date: 2025-09-07 07:33+0800\n"
 "Last-Translator: \n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
@@ -16,6 +16,7 @@ msgstr ""
 "X-Crowdin-Language: zh-CN\n"
 "X-Crowdin-File: nvda.pot\n"
 "X-Crowdin-File-ID: 2\n"
+"X-Generator: Poedit 3.7\n"
 
 #. Translators: A mode  that allows typing in the actual 'native' characters for an east-Asian input method language currently selected, rather than alpha numeric (Roman/English) characters.
 #: NVDAHelper.py:486
@@ -854,7 +855,7 @@ msgstr "蓝牙串行设备：{port} ({deviceName})"
 #: brailleDisplayDrivers\papenmeier_serial.py:81
 #, python-brace-format
 msgid "Serial: {portName}"
-msgstr "系列：{portName}"
+msgstr "串行：{portName}"
 
 #. Translators: Reported when translation didn't succeed due to unsupported input.
 #: brailleInput.py:250
@@ -893,13 +894,13 @@ msgstr "盲文键盘"
 #. along with any dots on a braille keyboard.
 #: brailleInput.py:570
 msgid "space with any dots"
-msgstr "any dots 空格"
+msgstr "空格加任意点位"
 
 #. Translators: Used to describe the press of any dots
 #. on a braille keyboard.
 #: brailleInput.py:574
 msgid "any dots"
-msgstr "任何凸点"
+msgstr "任意点位"
 
 #. Translators: The mode to interact with controls in documents
 #: browseMode.py:75
@@ -1042,22 +1043,22 @@ msgstr "往上没有链接"
 #. Translators: Input help message for a quick navigation command in browse mode.
 #: browseMode.py:849
 msgid "moves to the next visited link"
-msgstr "移到下一个以访问的链接"
+msgstr "移到下一个已访问的链接"
 
 #. Translators: Message presented when the browse mode element is not found.
 #: browseMode.py:851
 msgid "no next visited link"
-msgstr "往下没有以访问的链接"
+msgstr "往下没有已访问的链接"
 
 #. Translators: Input help message for a quick navigation command in browse mode.
 #: browseMode.py:853
 msgid "moves to the previous visited link"
-msgstr "移到上一个以访问的链接"
+msgstr "移到上一个已访问的链接"
 
 #. Translators: Message presented when the browse mode element is not found.
 #: browseMode.py:855
 msgid "no previous visited link"
-msgstr "往上没有以访问的链接"
+msgstr "往上没有已访问的链接"
 
 #. Translators: Input help message for a quick navigation command in browse mode.
 #: browseMode.py:861
@@ -2128,9 +2129,11 @@ msgstr[0] "以下插件安装失败：{}。"
 #. {failureMsg} will be replaced with the specific error message.
 #: core.py:117
 #, python-brace-format
-msgid "Some operations on add-ons failed. See the log file for more details.\n"
+msgid ""
+"Some operations on add-ons failed. See the log file for more details.\n"
 "{failureMsg}"
-msgstr "对插件的某些操作失败。有关更多详细信息，请参阅日志文件。\n"
+msgstr ""
+"对插件的某些操作失败。有关更多详细信息，请参阅日志文件。\n"
 "{failureMsg}"
 
 #. Translators: Title of message shown when requested action on add-ons failed.
@@ -2191,9 +2194,11 @@ msgstr "未知的命令行参数"
 
 #. Translators: A message informing the user that there are errors in the configuration file.
 #: core.py:162
-msgid "Your configuration file contains errors. Your configuration has been reset to factory defaults.\n"
+msgid ""
+"Your configuration file contains errors. Your configuration has been reset to factory defaults.\n"
 "More details about the errors can be found in the log file."
-msgstr "您的配置文件包含错误。您的配置已经被重置为默认设置。\n"
+msgstr ""
+"您的配置文件包含错误。您的配置已经被重置为默认设置。\n"
 "如需了解错误详细信息，请查看日志文件。"
 
 #. Translators: The title of the dialog to tell users that there are errors in the configuration file.
@@ -2202,9 +2207,11 @@ msgid "Configuration File Error"
 msgstr "配置文件错误"
 
 #: core.py:185
-msgid "Your gesture map file contains errors.\n"
+msgid ""
+"Your gesture map file contains errors.\n"
 "More details about the errors can be found in the log file."
-msgstr "您的手势映射文件包含错误。\n"
+msgstr ""
+"您的手势映射文件包含错误。\n"
 "如果需要了解此错误的详细信息，请查看日志文件。"
 
 #: core.py:188
@@ -3573,9 +3580,11 @@ msgstr "无替换文本"
 #. Translators: Character and its replacement used from the "Review current Symbol" command. Example: "Character: ? Replacement: question"
 #: globalCommands.py:2358
 #, python-brace-format
-msgid "Character: {character}\n"
+msgid ""
+"Character: {character}\n"
 "Replacement: {replacement}"
-msgstr "符号：{character}\n"
+msgstr ""
+"符号：{character}\n"
 "替换文本：{replacement}"
 
 #. Translators: title for expanded symbol dialog. Example: "Expanded symbol (English)"
@@ -4936,7 +4945,7 @@ msgstr "搜索页"
 #. Translators: This is the name of the favorites key found on multimedia keyboards to open favorites in the web-browser.
 #: keyLabels.py:25
 msgid "favorites"
-msgstr "收藏家"
+msgstr "收藏夹"
 
 #. Translators: This is the name of the home key found on multimedia keyboards to goto the home page in the web-browser.
 #: keyLabels.py:27
@@ -5096,7 +5105,7 @@ msgstr "下光标"
 #. Translators: This is the name of a key on the keyboard.
 #: keyLabels.py:91
 msgid "applications"
-msgstr "application"
+msgstr "applications"
 
 #. Translators: This is the name of a key on the keyboard.
 #: keyLabels.py:93
@@ -5687,7 +5696,7 @@ msgstr "十二边形"
 #: msoAutoShapeTypes.py:312
 msgctxt "shape"
 msgid "Donut"
-msgstr "同心圆"
+msgstr "圆环形"
 
 #. Translators: a shape name from Microsoft Office.
 #. See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
@@ -5988,7 +5997,7 @@ msgstr "心形"
 #: msoAutoShapeTypes.py:447
 msgctxt "shape"
 msgid "Heptagon"
-msgstr "正五边形"
+msgstr "七边形"
 
 #. Translators: a shape name from Microsoft Office.
 #. See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
@@ -6289,7 +6298,7 @@ msgstr "燕尾形箭头"
 #: msoAutoShapeTypes.py:594
 msgctxt "shape"
 msgid "Octagon"
-msgstr "十边形"
+msgstr "八边形"
 
 #. Translators: a shape name from Microsoft Office.
 #. See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
@@ -6583,14 +6592,14 @@ msgstr "动作按钮: 后退或前一项"
 #: msoAutoShapeTypes.py:729
 msgctxt "action"
 msgid "Beginning"
-msgstr "动作按钮: 前进或下一项"
+msgstr "动作按钮: 开始"
 
 #. Translators: an action button label from Microsoft Office.
 #. See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 #: msoAutoShapeTypes.py:732
 msgctxt "action"
 msgid "Document"
-msgstr "动作按钮: 开始"
+msgstr "动作按钮: 文档"
 
 #. Translators: an action button label from Microsoft Office.
 #. See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
@@ -6993,7 +7002,8 @@ msgstr "正在检查更新"
 #: updateCheck.py:409
 #, python-brace-format
 msgctxt "updateCheck"
-msgid "Make sure you are connected to the internet, and the NVDA update mirror URL is valid.\n"
+msgid ""
+"Make sure you are connected to the internet, and the NVDA update mirror URL is valid.\n"
 "Mirror URL: {url}"
 msgstr "请检查网络连接，并确保更新镜像网址 {url} 有效。"
 
@@ -7008,9 +7018,11 @@ msgstr "无法连接到 NV Access 服务器。"
 #: updateCheck.py:422
 #, python-brace-format
 msgctxt "updateCheck"
-msgid "Error checking for update.\n"
+msgid ""
+"Error checking for update.\n"
 "{tip}"
-msgstr "检查更新时出错。\n"
+msgstr ""
+"检查更新时出错。\n"
 "{tip}"
 
 #. Translators: The title of the dialog informing the user about an NVDA update.
@@ -7115,12 +7127,14 @@ msgstr "下载更新时出错。"
 
 #. Translators: The message requesting donations from users.
 #: updateCheck.py:939
-msgid "We need your help in order to continue to improve NVDA.\n"
+msgid ""
+"We need your help in order to continue to improve NVDA.\n"
 "This project relies primarily on donations and grants. By donating, you are helping to fund full time development.\n"
 "If even $10 is donated for every download, we will be able to cover all of the ongoing costs of the project.\n"
 "All donations are received by NV Access, the non-profit organisation which develops NVDA.\n"
 "Thank you for your support."
-msgstr "我们需要您的帮助，以便持续改进 NVDA。\n"
+msgstr ""
+"我们需要您的帮助，以便持续改进 NVDA。\n"
 "此项目主要依靠捐赠和资助，您的捐赠将帮助用于全职开发。\n"
 "即使每次下载只有 10 美元的捐赠，我们也能够支付项目的所有持续费用。\n"
 "所有的捐款都由开发 NVDA 的非营利组织 NV Access 接收。\n"
@@ -7159,10 +7173,14 @@ msgstr "不建议在作为被控计算机连接到 NVDA 远程访问时更新 NV
 #. Translators: Message shown to users when attempting to update NVDA from an installed copy
 #. on a computer which is being remotely controlled via NVDA Remote Access.
 #: updateCheck.py:1012
-msgid "The currently active connection may not be continued during or after the update. Even if the connection is continued, you will be unable to respond to User Account Control (UAC) prompts from the controlling computer. You should only proceed if you have physical access to the controlled computer.\n\n"
+msgid ""
+"The currently active connection may not be continued during or after the update. Even if the connection is continued, you will be unable to respond to User Account Control (UAC) prompts from the controlling computer. You should only proceed if you have physical access to the controlled computer.\n"
+"\n"
 "Are you sure you want to continue?"
-msgstr "更新期间或更新后，当前活动连接可能无法保持。即使连接保持，您也将无法从主控计算机响应用户帐户控制（UAC）提示。\n"
-"仅在您能物理访问被控计算机的情况下才可继续操作。\n\n"
+msgstr ""
+"更新期间或更新后，当前活动连接可能无法保持。即使连接保持，您也将无法从主控计算机响应用户帐户控制（UAC）提示。\n"
+"仅在您能物理访问被控计算机的情况下才可继续操作。\n"
+"\n"
 "您确定要继续吗？"
 
 #. Translators: The title of a dialog.
@@ -7195,22 +7213,28 @@ msgstr "NVDA 贡献者版权所有 {years}"
 #. Translators: "About NVDA" dialog box message
 #: versionInfo.py:23
 #, python-brace-format
-msgid "{longName} ({name})\n"
+msgid ""
+"{longName} ({name})\n"
 "Version: {version} ({version_detailed})\n"
 "URL: {url}\n"
-"{copyright}\n\n"
+"{copyright}\n"
+"\n"
 "{name} is covered by the GNU General Public License (Version 2). You are free to share or change this software in any way you like as long as it is accompanied by the license and you make all source code available to anyone who wants it. This applies to both original and modified copies of this software, plus any derivative works.\n"
 "For further details, you can view the license from the Help menu.\n"
-"It can also be viewed online at: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\n\n"
+"It can also be viewed online at: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\n"
+"\n"
 "{name} is developed by NV Access, a non-profit organisation committed to helping and promoting free and open source solutions for blind and vision impaired people.\n"
 "If you find NVDA useful and want it to continue to improve, please consider donating to NV Access. You can do this by selecting Donate from the NVDA menu."
-msgstr "{longName}（{name}）\n"
+msgstr ""
+"{longName}（{name}）\n"
 "版本：{version} ({version_detailed})\n"
 "网址：{url}\n"
-"{copyright}\n\n"
+"{copyright}\n"
+"\n"
 "{name} 遵循 GNU 通用公共授权协议第二版， 您可以自由分享或者以任何方式修改本软件，但在重新发布时必须包含本协议，同时必须公开原版和修改版的源代码，并附上任何用本软件的源代码所产生的软件。\n"
 "关于本授权协议的详情,您可以通过“帮助”菜单的“版权信息”访问。\n"
-"您也可参看以下网页：https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\n\n"
+"您也可参看以下网页：https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\n"
+"\n"
 "{name} 是由非赢利组织“NV Access”开发的一个用于协助视障用户的免费且开放源代码的解决方案。\n"
 "如果您觉得 NVDA 对您很有帮助，并希望它能不断完善，请考虑向 NV Access 捐款。您可通过 NVDA 菜单中的“立即捐赠”选项完成操作。"
 
@@ -7218,9 +7242,11 @@ msgstr "{longName}（{name}）\n"
 #. from windows explorer and NVDA is not running.
 #: nvda_slave.pyw:115
 #, python-brace-format
-msgid "Cannot install NVDA add-on from {path}.\n"
+msgid ""
+"Cannot install NVDA add-on from {path}.\n"
 "You must be running NVDA to be able to install add-ons."
-msgstr "无法从 {path} 安装插件。\n"
+msgstr ""
+"无法从 {path} 安装插件。\n"
 "您必须先运行 NVDA 以使插件可以顺利的安装。"
 
 #. Translators: A title of the dialog shown when fetching add-on data from the store fails
@@ -7234,7 +7260,8 @@ msgstr "插件数据更新失败"
 #: addonStore\dataManager.py:217
 #, python-brace-format
 msgctxt "addonStore"
-msgid "Make sure you are connected to the internet, and the Add-on Store mirror URL is valid.\n"
+msgid ""
+"Make sure you are connected to the internet, and the Add-on Store mirror URL is valid.\n"
 "Mirror URL: {url}"
 msgstr "请检查网络连接，并确保插件商店镜像网址 {url} 有效。"
 
@@ -7579,7 +7606,8 @@ msgstr "已安装的不兼容插件(&A)"
 #, python-brace-format
 msgctxt "addonStore"
 msgid "An updated version of NVDA is required. NVDA version {nvdaVersion} or later."
-msgstr "需要更高版本的 NVDA。\n"
+msgstr ""
+"需要更高版本的 NVDA。\n"
 "NVDA {nvdaVersion} 或更高。"
 
 #. Translators: The reason an add-on is not compatible.
@@ -7589,16 +7617,18 @@ msgstr "需要更高版本的 NVDA。\n"
 #, python-brace-format
 msgctxt "addonStore"
 msgid "An updated version of this add-on is required. This add-on was last tested with NVDA {lastTestedNVDAVersion}. NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. You can enable this add-on at your own risk. "
-msgstr "您安装的插件版本太旧，需要更新。\n"
+msgstr ""
+"您安装的插件版本太旧，需要更新。\n"
 "该插件已在 NVDA {lastTestedNVDAVersion} 测试。此版本的 NVDA 要求该插件在 {nvdaVersion} 或更高版本的 NVDA 进行测试。\n"
-"您需要字形承担启用该插件的风险。"
+"您需要自行承担启用该插件的风险。"
 
 #. Translators: A message indicating that some add-ons will be disabled
 #. unless reviewed before installation.
 #: addonStore\models\version.py:145
 msgctxt "addonStore"
 msgid "Your NVDA configuration contains add-ons that are incompatible with this version of NVDA. These add-ons will be disabled after installation. After installation, you will be able to manually re-enable these add-ons at your own risk. If you rely on these add-ons, please review the list to decide whether to continue with the installation. "
-msgstr "您的配置中含有与该版本 NVDA 不兼容的插件。\n"
+msgstr ""
+"您的配置中含有与该版本 NVDA 不兼容的插件。\n"
 "NVDA 安装后这些插件会被禁用。安装完成后您可以手动启用这些插件，但需自行承担风险。\n"
 "如果您依赖这些插件，请查看“不兼容的插件”列表以决定是否继续安装。"
 
@@ -10341,7 +10371,7 @@ msgstr "x-大号"
 #: controlTypes\formatFields.py:72
 msgctxt "font size"
 msgid "xx-large"
-msgstr "xs-大号"
+msgstr "xx-大号"
 
 #. Translators: A measurement unit of font size.
 #: controlTypes\formatFields.py:74
@@ -10651,7 +10681,7 @@ msgstr "下拉按钮"
 #. Translators: Identifies an element.
 #: controlTypes\role.py:287
 msgid "clock"
-msgstr "时锺"
+msgstr "时钟"
 
 #. Translators: Identifies a separator (a horizontal line drawn on the screen).
 #: controlTypes\role.py:289
@@ -10869,7 +10899,7 @@ msgstr "分组窗格"
 #. This is deprecated and is not often (if ever) used.
 #: controlTypes\role.py:379
 msgid "edit bar"
-msgstr "编辑兰"
+msgstr "编辑栏"
 
 #. Translators: Identifies a terminal window such as command prompt.
 #: controlTypes\role.py:381
@@ -10880,7 +10910,7 @@ msgstr "终端"
 #. addition to text; encountered on webpages and NvDA log viewer).
 #: controlTypes\role.py:384
 msgid "rich edit"
-msgstr "多功能编辑控件"
+msgstr "富文本编辑框"
 
 #. Translators: Identifies a ruler object (commonly seen on some webpages and in some Office programs).
 #: controlTypes\role.py:386
@@ -10994,7 +11024,7 @@ msgstr "数学"
 #. Translators: Identifies a grip control.
 #: controlTypes\role.py:432
 msgid "grip"
-msgstr "控制"
+msgstr "手柄"
 
 #. Translators: Identifies a hot key field (a field where one can enter a hot key for something, such as
 #. assigning shortcut for icons on the desktop).
@@ -11156,7 +11186,7 @@ msgstr "标题项目"
 #. Translators: Identifies a thumb control (a button-like control for changing options).
 #: controlTypes\role.py:505
 msgid "thumb control"
-msgstr "触摸控件"
+msgstr "拖动控件"
 
 #: controlTypes\role.py:506
 msgid "calendar"
@@ -11305,7 +11335,7 @@ msgstr "不可见"
 #. Translators: This is presented when a visited link is encountered.
 #: controlTypes\state.py:139
 msgid "visited"
-msgstr "以访问"
+msgstr "已访问"
 
 #. Translators: This is presented when a link is encountered.
 #: controlTypes\state.py:141
@@ -11597,13 +11627,14 @@ msgstr "确保您已连接到互联网且网址正确。"
 #: gui\_SetURLDialog.py:209
 #, python-brace-format
 msgid "The URL you have entered failed the connection test. {tip}"
-msgstr "您输入的网址连接测试失败。\n"
+msgstr ""
+"您输入的网址连接测试失败。\n"
 "{tip}"
 
 #. Translators: Reported when last saved configuration has been applied by using revert to saved configuration option in NVDA menu.
 #: gui\__init__.py:212
 msgid "Configuration applied"
-msgstr "配置以应用"
+msgstr "配置已应用"
 
 #. Translators: Reported when configuration has been restored to defaults,
 #. by using restore configuration to factory defaults item in NVDA menu.
@@ -11614,7 +11645,7 @@ msgstr "恢复默认设置"
 #. Translators: Reported when current configuration has been saved.
 #: gui\__init__.py:232
 msgid "Configuration saved"
-msgstr "配置以保存"
+msgstr "配置已保存"
 
 #. Translators: Message shown when current configuration cannot be saved,
 #. such as when running NVDA from a CD.
@@ -11640,13 +11671,21 @@ msgstr "关于 NVDA"
 
 #. Translators: Explain the COM Registration Fixing tool to users before running
 #: gui\__init__.py:517
-msgid "Welcome to the COM Registration Fixing tool.\n\n"
-"Installing and uninstalling programs, as well as other events, can damage accessibility entries in the Windows registry. This can cause previously accessible elements to be presented incorrectly, or can cause \"unknown\" or \"pane\" to be spoken or brailled in some applications or Windows components, instead of the content you were expecting.\n\n"
-"This tool attempts to fix such common problems. Note that the tool must access the system registry, which requires administrative privileges.\n\n"
+msgid ""
+"Welcome to the COM Registration Fixing tool.\n"
+"\n"
+"Installing and uninstalling programs, as well as other events, can damage accessibility entries in the Windows registry. This can cause previously accessible elements to be presented incorrectly, or can cause \"unknown\" or \"pane\" to be spoken or brailled in some applications or Windows components, instead of the content you were expecting.\n"
+"\n"
+"This tool attempts to fix such common problems. Note that the tool must access the system registry, which requires administrative privileges.\n"
+"\n"
 "Press Continue to run the tool now."
-msgstr "欢迎使用 COM 注册修复工具。\n\n"
-"安装或卸载程序及其他事件可能会损坏 Windows 注册表中的辅助功能条目。这可能导致以前可访问的元素显示不正确，或在某些应用程序及 Windows 组件中输出“未知”或“窗格”，而不是您期望的内容。\n\n"
-"该工具将尝试修复此类常见问题。请注意，该工具必须访问系统注册表，这需要管理员权限。\n\n"
+msgstr ""
+"欢迎使用 COM 注册修复工具。\n"
+"\n"
+"安装或卸载程序及其他事件可能会损坏 Windows 注册表中的辅助功能条目。这可能导致以前可访问的元素显示不正确，或在某些应用程序及 Windows 组件中输出“未知”或“窗格”，而不是您期望的内容。\n"
+"\n"
+"该工具将尝试修复此类常见问题。请注意，该工具必须访问系统注册表，这需要管理员权限。\n"
+"\n"
 "按“继续”立即运行该工具。"
 
 #. Translators: The title of various dialogs displayed when using the COM Registration Fixing tool
@@ -11662,9 +11701,11 @@ msgstr "请稍候，NVDA 正在尝试修复系统中的 COM 注册……"
 #. Translators: message shown to the user on COM Registration Fix fail
 #: gui\__init__.py:584
 #, python-brace-format
-msgid "The COM Registration Fixing Tool was unsuccessful. This Windows error may provide more information.\n"
+msgid ""
+"The COM Registration Fixing Tool was unsuccessful. This Windows error may provide more information.\n"
 "{error}"
-msgstr "COM 注册修复工具未能成功运行。此 Windows 错误可能提供更多信息。\n"
+msgstr ""
+"COM 注册修复工具未能成功运行。此 Windows 错误可能提供更多信息。\n"
 "{error}"
 
 #. Translators: The title of a COM Registration Fixing Tool dialog, when the tool has failed
@@ -11674,7 +11715,8 @@ msgstr "COM 注册修复失败"
 
 #. Translators: Message shown when the COM Registration Fixing tool completes.
 #: gui\__init__.py:595
-msgid "The COM Registration Fixing Tool has completed successfully.\n"
+msgid ""
+"The COM Registration Fixing Tool has completed successfully.\n"
 "It is highly recommended that you restart your computer now, to make sure the changes take full effect."
 msgstr "COM 注册修复工具已完成。强烈建议您现在重新启动计算机，以确保更改完全生效。"
 
@@ -11810,7 +11852,7 @@ msgstr "管理配置(&C)..."
 #. Translators: The label for the menu item to revert to saved configuration.
 #: gui\__init__.py:782
 msgid "&Revert to saved configuration"
-msgstr "重新应用以保存的设置(&R)"
+msgstr "重新应用已保存的配置(&R)"
 
 #. Translators: The help text for the menu item to revert to saved configuration.
 #: gui\__init__.py:784
@@ -12127,7 +12169,7 @@ msgstr "手动"
 #. in the Configuration Profiles dialog.
 #: gui\configProfiles.py:155
 msgid "triggered"
-msgstr "以关联"
+msgstr "已关联"
 
 #. Translators: An error displayed when activating a configuration profile fails.
 #: gui\configProfiles.py:180
@@ -12251,9 +12293,11 @@ msgstr "此配置的使用条件为："
 #. Translators: The confirmation prompt presented when creating a new configuration profile
 #. and the selected trigger is already associated.
 #: gui\configProfiles.py:496
-msgid "This trigger is already associated with another profile. If you continue, it will be removed from that profile and associated with this one.\n"
+msgid ""
+"This trigger is already associated with another profile. If you continue, it will be removed from that profile and associated with this one.\n"
 "Are you sure you want to continue?"
-msgstr "此关联已经与其他配置连接。如果您继续，旧的配置连接将被此连接替换。\n"
+msgstr ""
+"此关联已经与其他配置连接。如果您继续，旧的配置连接将被此连接替换。\n"
 "您希望继续吗？"
 
 #. Translators: An error displayed when the user attempts to create a configuration profile
@@ -12270,9 +12314,11 @@ msgstr "保存配置时发生错误，文件系统可能处于只读状态。"
 #. Translators: The prompt asking the user whether they wish to
 #. manually activate a configuration profile that has just been created.
 #: gui\configProfiles.py:558
-msgid "To edit this profile, you will need to manually activate it. Once you have finished editing, you will need to manually deactivate it to resume normal usage.\n"
+msgid ""
+"To edit this profile, you will need to manually activate it. Once you have finished editing, you will need to manually deactivate it to resume normal usage.\n"
 "Do you wish to manually activate it now?"
-msgstr "要想编辑此配置，您必须先将其激活。一旦您完成编辑，您必须手动禁用它已使配置恢复到原来的状态。\n"
+msgstr ""
+"要想编辑此配置，您必须先将其激活。一旦您完成编辑，您必须手动禁用它已使配置恢复到原来的状态。\n"
 "您希望现在就手动激活它吗？"
 
 #. Translators: The title of the confirmation dialog for manual activation of a created profile.
@@ -12395,12 +12441,16 @@ msgstr "重置(&D)"
 
 #. Translators: A prompt for confirmation to reset all gestures in the Input Gestures dialog.
 #: gui\inputGestures.py:789
-msgid "Are you sure you want to reset all gestures to their factory defaults?\n\n"
+msgid ""
+"Are you sure you want to reset all gestures to their factory defaults?\n"
+"\n"
 "\t\t\tAll of your user defined gestures, whether previously set or defined during this session, will be lost.\n"
 "\t\t\tThis cannot be undone."
-msgstr "您是否要将所有按键与手势重置为默认值？\n"
-"\t\t\t\n"
-"重置后，您先前保存和设置的所有按键与手势都将丢失且无法撤销。"
+msgstr ""
+"您是否要将所有按键与手势重置为默认值？\n"
+"\n"
+"\t\t\t重置后，您先前保存和设置的所有按键与手势都将丢失。\n"
+"\t\t\t该操作无法撤销。"
 
 #. Translators: A prompt for confirmation to reset all gestures in the Input Gestures dialog.
 #: gui\inputGestures.py:794
@@ -12566,10 +12616,14 @@ msgstr "不建议在作为被控计算机连接到 NVDA 远程访问时安装 NV
 #. Translators: Message shown to users when attempting to install or update NVDA from the launcher
 #. on a computer which is being remotely controlled via NVDA Remote Access
 #: gui\installerGui.py:468
-msgid "You will be unable to respond to User Account Control (UAC) prompts from the controlling computer. You should only proceed if you have physical access to the controlled computer.\n\n"
+msgid ""
+"You will be unable to respond to User Account Control (UAC) prompts from the controlling computer. You should only proceed if you have physical access to the controlled computer.\n"
+"\n"
 "Are you sure you want to continue?"
-msgstr "您将无法从主控计算机响应用户帐户控制（UAC）提示。\n"
-"仅在您能物理访问被控计算机的情况下才可继续操作。\n\n"
+msgstr ""
+"您将无法从主控计算机响应用户帐户控制（UAC）提示。\n"
+"仅在您能物理访问被控计算机的情况下才可继续操作。\n"
+"\n"
 "您确定要继续吗？"
 
 #. Translators: The title of the Create Portable NVDA dialog.
@@ -12735,10 +12789,14 @@ msgstr "默认（{default}）"
 #. Translators: Content of the message displayed when a validation error occurs in the settings dialog
 #: gui\settingsDialogs.py:444
 #, python-brace-format
-msgid "{message}\n\n"
+msgid ""
+"{message}\n"
+"\n"
 "Category: \"{category}\"\n"
 "Option: \"{option}\""
-msgstr "“{option}”提示“{message}”\n\n"
+msgstr ""
+"“{option}”提示“{message}”\n"
+"\n"
 "该选项位于“{category}”类别下。"
 
 #. Translators: The title of the message box when a setting's configuration is not valid.
@@ -12840,7 +12898,7 @@ msgstr "在欢迎界面启用 NVDA（需要管理员权限）"
 #. Control (UAC) dialog).
 #: gui\settingsDialogs.py:913
 msgid "Use currently saved settings during sign-in and on secure screens (requires administrator privileges)"
-msgstr "应用以保存的配置到欢迎界面和其他安全界面（需要管理员权限）"
+msgstr "应用已保存的配置到欢迎界面和其他安全界面（需要管理员权限）"
 
 #. Translators: The label of a checkbox in general settings to toggle automatic checking for updated versions of NVDA.
 #. If not checked, user must check for updates manually.
@@ -13073,7 +13131,8 @@ msgstr "移动光标后读出字符解释(&D)"
 #. Translators: Warning shown when 'talk' speech mode is disabled in settings.
 #: gui\settingsDialogs.py:1974
 msgid "You did not choose Talk as one of your speech mode options. Please note that this may result in no speech output at all. Are you sure you want to continue?"
-msgstr "您将取消“正常朗读”作为可切换的语音模式之一。\n"
+msgstr ""
+"您将取消“正常朗读”作为可切换的语音模式之一。\n"
 "请注意，这可能导致没有语音输出。\n"
 "您确定要继续吗？"
 
@@ -13863,10 +13922,14 @@ msgstr "删除所有已信任的指纹"
 #. Translators: This message is presented when the user tries to delete all stored trusted fingerprints.
 #: gui\settingsDialogs.py:3574
 msgctxt "remote"
-msgid "This will cause NVDA to forget all previously trusted Remote Access servers. When connecting to a previously trusted unrecognised server, you will again be asked whether to trust its certificate.\n\n"
+msgid ""
+"This will cause NVDA to forget all previously trusted Remote Access servers. When connecting to a previously trusted unrecognised server, you will again be asked whether to trust its certificate.\n"
+"\n"
 "Are you sure you want to continue?"
-msgstr "这将导致 NVDA 忘记所有之前受信任的远程访问服务器。\n"
-"当连接到之前受信任但未经验证的服务器时，系统将再次询问是否信任其证书。\n\n"
+msgstr ""
+"这将导致 NVDA 忘记所有之前受信任的远程访问服务器。\n"
+"当连接到之前受信任但未经验证的服务器时，系统将再次询问是否信任其证书。\n"
+"\n"
 "您确定要继续吗？"
 
 #. Translators: This is the title of the dialog presented when the user tries to delete all stored trusted fingerprints.
@@ -14044,9 +14107,11 @@ msgstr "旧版"
 #. Note the '\n' is used to split this long label approximately in half.
 #: gui\settingsDialogs.py:3874
 msgctxt "advanced.uiaWithChromium"
-msgid "Use UIA with Microsoft Edge and other \n"
+msgid ""
+"Use UIA with Microsoft Edge and other \n"
 "&Chromium based browsers when available:"
-msgstr "在 Microsoft Edge 及其他基于 Chromium 内核的浏览器中\n"
+msgstr ""
+"在 Microsoft Edge 及其他基于 Chromium 内核的浏览器中\n"
 "启用 UIA 接口（如果可用）(&C)："
 
 #. Translators: Label for the default value of the Use UIA with Chromium combobox,
@@ -14273,7 +14338,8 @@ msgstr "警告！"
 #. Translators: This is a label appearing on the Advanced settings panel.
 #: gui\settingsDialogs.py:4363
 msgid "The following settings are for advanced users. Changing them may cause NVDA to function incorrectly. Please only change these if you know what you are doing or have been specifically instructed by NVDA developers."
-msgstr "以下设置适用于高级用户,修改这些设置可能会导致 NVDA 无法正常运行。\n"
+msgstr ""
+"以下设置适用于高级用户,修改这些设置可能会导致 NVDA 无法正常运行。\n"
 "只有在清楚要更改选项的含义、或在 NVDA 开发者的指导下，才可进行修改。"
 
 #. Translators: This is the label for a checkbox in the Advanced settings panel.
@@ -14448,9 +14514,11 @@ msgstr "无法加载 {providerName} 视觉增强提供程序"
 #. load multiple vision enhancement providers.
 #: gui\settingsDialogs.py:5124
 #, python-brace-format
-msgid "Could not load the following vision enhancement providers:\n"
+msgid ""
+"Could not load the following vision enhancement providers:\n"
 "{providerNames}"
-msgstr "无法加载以下视觉增强提供程序：\n"
+msgstr ""
+"无法加载以下视觉增强提供程序：\n"
 "{providerNames}"
 
 #. Translators: The title of the vision enhancement provider error message box.
@@ -14469,9 +14537,11 @@ msgstr "无法正常终止 {providerName} 视觉增强提供程序"
 #. NVDA is unable to terminate multiple vision enhancement providers.
 #: gui\settingsDialogs.py:5155
 #, python-brace-format
-msgid "Could not gracefully terminate the following vision enhancement providers:\n"
+msgid ""
+"Could not gracefully terminate the following vision enhancement providers:\n"
 "{providerNames}"
-msgstr "无法正常终止以下视觉增强提供程序：\n"
+msgstr ""
+"无法正常终止以下视觉增强提供程序：\n"
 "{providerNames}"
 
 #. Translators: This is a label appearing on the vision settings panel.
@@ -14720,12 +14790,14 @@ msgstr "临时字典"
 
 #. Translators: The main message for the Welcome dialog when the user starts NVDA for the first time.
 #: gui\startupDialogs.py:38
-msgid "Most commands for controlling NVDA require you to hold down the NVDA key while pressing other keys.\n"
+msgid ""
+"Most commands for controlling NVDA require you to hold down the NVDA key while pressing other keys.\n"
 "By default, the Insert and numpad Insert keys may both be used as the NVDA key.\n"
 "You can also configure NVDA to use the CapsLock as the NVDA key.\n"
 "Press NVDA+n at any time to activate the NVDA menu.\n"
 "From this menu, you can configure NVDA, get help, and access other NVDA functions."
-msgstr "大多数控制 NVDA 的命令要求您在按住 NVDA 键的同时按其他键。\n"
+msgstr ""
+"大多数控制 NVDA 的命令要求您在按住 NVDA 键的同时按其他键。\n"
 "默认情况下，主键盘和数字键盘的插入键都可以用作 NVDA 键。\n"
 "您还可以将 NVDA 配置为使用大写锁定键作为 NVDA 键。\n"
 "随时可按 NVDA+n 激活 NVDA 菜单。\n"
@@ -14795,10 +14867,14 @@ msgstr "NVDA 使用数据收集"
 
 #. Translators: A message asking the user if they want to allow usage stats gathering
 #: gui\startupDialogs.py:282
-msgid "In order to improve NVDA in the future, NV Access wishes to collect usage data from running copies of NVDA.\n\n"
-"Data includes Operating System version, NVDA version, language, country of origin, plus certain NVDA configuration such as current synthesizer, braille display and braille table. No spoken or braille content will be ever sent to NV Access. Please refer to the User Guide for a current list of all data collected.\n\n"
+msgid ""
+"In order to improve NVDA in the future, NV Access wishes to collect usage data from running copies of NVDA.\n"
+"\n"
+"Data includes Operating System version, NVDA version, language, country of origin, plus certain NVDA configuration such as current synthesizer, braille display and braille table. No spoken or braille content will be ever sent to NV Access. Please refer to the User Guide for a current list of all data collected.\n"
+"\n"
 "Do you wish to allow NV Access to periodically collect this data in order to improve NVDA?"
-msgstr "为了在未来改进 NVDA，NV Access 希望从正在运行的 NVDA 副本收集使用数据。\n"
+msgstr ""
+"为了在未来改进 NVDA，NV Access 希望从正在运行的 NVDA 副本收集使用数据。\n"
 "数据包括操作系统版本、NVDA 版本、语言、所在国家/地区、以及某些 NVDA 配置，如语音合成器，盲文点显器和盲文表等。\n"
 "NVDA 不会将语音或盲文内容发送给 NV Access。\n"
 "关于收集数据的完整列表，请参阅用户指南的数据收集部分。\n"
@@ -15041,9 +15117,11 @@ msgstr "记住此选择"
 #: gui\addonStoreGui\controls\messageDialogs.py:118
 #, python-brace-format
 msgctxt "addonStore"
-msgid "Warning: add-on installation may result in downgrade: {name}. The installed add-on version cannot be compared with the add-on store version. Installed version: {oldVersion}. Available version: {version}.\n"
+msgid ""
+"Warning: add-on installation may result in downgrade: {name}. The installed add-on version cannot be compared with the add-on store version. Installed version: {oldVersion}. Available version: {version}.\n"
 "Proceed with installation anyway? "
-msgstr "警告：安装 {name} 可能会导致降级。无法将已安装的插件版本与插件商店的版本进行比较。已安装版本：{oldVersion}。可安装版本：{version}。\n"
+msgstr ""
+"警告：安装 {name} 可能会导致降级。无法将已安装的插件版本与插件商店的版本进行比较。已安装版本：{oldVersion}。可安装版本：{version}。\n"
 "您仍要安装该插件吗？"
 
 #. Translators: The title of a dialog presented when an error occurs.
@@ -15072,9 +15150,11 @@ msgstr "移除插件"
 #: gui\addonStoreGui\controls\messageDialogs.py:174
 #, python-brace-format
 msgctxt "addonStore"
-msgid "Warning: add-on is incompatible: {name} {version}. Check for an updated version of this add-on if possible. This add-on was last tested with NVDA {lastTestedNVDAVersion}. NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. Installation may cause unstable behavior in NVDA.\n"
+msgid ""
+"Warning: add-on is incompatible: {name} {version}. Check for an updated version of this add-on if possible. This add-on was last tested with NVDA {lastTestedNVDAVersion}. NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. Installation may cause unstable behavior in NVDA.\n"
 "Proceed with installation anyway? "
-msgstr "警告：插件不兼容：{name}-{version}。如果可能，请检查该插件有无新版本。\n"
+msgstr ""
+"警告：插件不兼容：{name}-{version}。如果可能，请检查该插件有无新版本。\n"
 "该插件已在 NVDA {lastTestedNVDAVersion} 测试。此版本的 NVDA 要求该插件在 {nvdaVersion} 或更高版本的 NVDA 进行测试。\n"
 "安装该插件可能会导致 NVDA 不稳定或无法正常运行。是否仍要安装？"
 
@@ -15083,9 +15163,11 @@ msgstr "警告：插件不兼容：{name}-{version}。如果可能，请检查�
 #: gui\addonStoreGui\controls\messageDialogs.py:207
 #, python-brace-format
 msgctxt "addonStore"
-msgid "Warning: add-on is incompatible: {name} {version}. Check for an updated version of this add-on if possible. This add-on was last tested with NVDA {lastTestedNVDAVersion}. NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. Enabling may cause unstable behavior in NVDA.\n"
+msgid ""
+"Warning: add-on is incompatible: {name} {version}. Check for an updated version of this add-on if possible. This add-on was last tested with NVDA {lastTestedNVDAVersion}. NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. Enabling may cause unstable behavior in NVDA.\n"
 "Proceed with enabling anyway? "
-msgstr "警告：插件不兼容：{name}-{version}。如果可能，请检查该插件有无新版本。\n"
+msgstr ""
+"警告：插件不兼容：{name}-{version}。如果可能，请检查该插件有无新版本。\n"
 "该插件已在 NVDA {lastTestedNVDAVersion} 测试。此版本的 NVDA 要求该插件在 {nvdaVersion} 或更高版本的 NVDA 进行测试。\n"
 "启用该插件可能会导致 NVDA 不稳定或无法正常运行。是否仍要启用？"
 
@@ -15111,10 +15193,12 @@ msgstr "插件安装失败"
 #. Translators: A message asking the user if they really wish to install an addon.
 #: gui\addonStoreGui\controls\messageDialogs.py:263
 #, python-brace-format
-msgid "Are you sure you want to install this add-on?\n"
+msgid ""
+"Are you sure you want to install this add-on?\n"
 "Only install add-ons from trusted sources.\n"
 "Addon: {summary} {version}"
-msgstr "您确定要安装此插件吗？\n"
+msgstr ""
+"您确定要安装此插件吗？\n"
 "请注意，仅安装来自可信来源的插件。\n"
 "插件: {summary} {version}"
 
@@ -15128,10 +15212,12 @@ msgstr "插件安装"
 #: gui\addonStoreGui\controls\messageDialogs.py:287
 #, python-brace-format
 msgctxt "addonStore"
-msgid "{summary} ({name})\n"
+msgid ""
+"{summary} ({name})\n"
 "Version: {version}\n"
 "Description: {description}\n"
-msgstr "{summary} ({name})\n"
+msgstr ""
+"{summary} ({name})\n"
 "版本：{version}\n"
 "描述：{description}\n"
 
@@ -16534,7 +16620,7 @@ msgstr "Y 误差线"
 #. Translators: A type of element in a Microsoft Office chart.
 #: NVDAObjects\window\_msOfficeChart.py:486
 msgid "Shape"
-msgstr "主石形状"
+msgstr "形状"
 
 #. Translators: Message reporting the title and type of a chart.
 #: NVDAObjects\window\_msOfficeChart.py:598
@@ -17664,7 +17750,7 @@ msgstr "右对齐"
 #. Translators: a an alignment in Microsoft Word
 #: NVDAObjects\window\winword.py:1819
 msgid "Justified"
-msgstr "段落重排"
+msgstr "两端对齐"
 
 #. Translators: a message when toggling formatting in Microsoft word
 #: NVDAObjects\window\winword.py:1857
@@ -18511,9 +18597,12 @@ msgstr "开启黑屏时播放声音(&P)"
 #. Translators: A warning shown when activating the screen curtain.
 #. the translation of "Screen Curtain" should match the "translated name"
 #: visionEnhancementProviders\screenCurtain.py:137
-msgid "Enabling Screen Curtain will make the screen of your computer completely black. Ensure you will be able to navigate without any use of your screen before continuing. \n\n"
+msgid ""
+"Enabling Screen Curtain will make the screen of your computer completely black. Ensure you will be able to navigate without any use of your screen before continuing. \n"
+"\n"
 "Do you wish to continue?"
-msgstr "开启黑屏将使计算机的屏幕完全变黑。在继续操作之前，请确保无需使用屏幕即可进行浏览。\n"
+msgstr ""
+"开启黑屏将使计算机的屏幕完全变黑。在继续操作之前，请确保无需使用屏幕即可进行浏览。\n"
 "您想继续吗？"
 
 #. Translators: option to enable screen curtain in the vision settings panel
@@ -18684,7 +18773,8 @@ msgstr "控制远程计算机"
 #, python-brace-format
 msgctxt "remote"
 msgid "Do you wish to control the computer on server {server} with key {key}?"
-msgstr "您要控制远程计算机嗎？\n"
+msgstr ""
+"您要控制远程计算机嗎？\n"
 "服务器: {server}，秘钥: {key}"
 
 #. Translators: Ask the user if they want to allow the remote computer to control this computer.
@@ -18692,7 +18782,8 @@ msgstr "您要控制远程计算机嗎？\n"
 #, python-brace-format
 msgctxt "remote"
 msgid "Do you wish to allow this computer to be controlled on server {server} with key {key}?"
-msgstr "您要允许此计算机被控制吗？\n"
+msgstr ""
+"您要允许此计算机被控制吗？\n"
 "服务器: {server}，秘钥: {key}"
 
 #. Translators: Title of the connection request dialog.
@@ -18826,13 +18917,20 @@ msgstr "安全警告"
 #: _remoteClient\dialogs.py:485
 #, python-brace-format
 msgctxt "remote"
-msgid "The certificate of this server could not be verified. Using the wrong fingerprint may allow a third party to access the Remote Access session.\n\n"
+msgid ""
+"The certificate of this server could not be verified. Using the wrong fingerprint may allow a third party to access the Remote Access session.\n"
+"\n"
 "Before continuing, please make sure that the following server certificate fingerprint is correct.\n"
-"Server SHA256 fingerprint: {fingerprint}\n\n"
+"Server SHA256 fingerprint: {fingerprint}\n"
+"\n"
 "Continue connecting anyway?"
-msgstr "该服务器的证书无法验证。使用错误的指纹可能会允许第三方访问远程访问会话。\n\n"
-"在继续之前，请确保以下服务器证书指纹正确。\n\n"
-"服务器 SHA256 指纹： {fingerprint}\n\n"
+msgstr ""
+"该服务器的证书无法验证。使用错误的指纹可能会允许第三方访问远程访问会话。\n"
+"\n"
+"在继续之前，请确保以下服务器证书指纹正确。\n"
+"\n"
+"服务器 SHA256 指纹： {fingerprint}\n"
+"\n"
 "您仍要继续连接吗？"
 
 #. Translators: A button to connect and remember the server with unauthorized certificate.
@@ -18948,4 +19046,3 @@ msgstr "来自远程访问服务器的消息"
 msgctxt "remote"
 msgid "Remote NVDA not connected"
 msgstr "远程 NVDA 未连接"
-

--- a/Translation/LC_MESSAGES/nvda.po
+++ b/Translation/LC_MESSAGES/nvda.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nvda\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-22 01:49+0000\n"
-"PO-Revision-Date: 2025-09-07 07:33+0800\n"
+"POT-Creation-Date: 2025-09-05 06:01+0000\n"
+"PO-Revision-Date: 2025-09-07 01:02\n"
 "Last-Translator: \n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
@@ -16,7 +16,6 @@ msgstr ""
 "X-Crowdin-Language: zh-CN\n"
 "X-Crowdin-File: nvda.pot\n"
 "X-Crowdin-File-ID: 2\n"
-"X-Generator: Poedit 3.7\n"
 
 #. Translators: A mode  that allows typing in the actual 'native' characters for an east-Asian input method language currently selected, rather than alpha numeric (Roman/English) characters.
 #: NVDAHelper.py:486
@@ -2129,11 +2128,9 @@ msgstr[0] "以下插件安装失败：{}。"
 #. {failureMsg} will be replaced with the specific error message.
 #: core.py:117
 #, python-brace-format
-msgid ""
-"Some operations on add-ons failed. See the log file for more details.\n"
+msgid "Some operations on add-ons failed. See the log file for more details.\n"
 "{failureMsg}"
-msgstr ""
-"对插件的某些操作失败。有关更多详细信息，请参阅日志文件。\n"
+msgstr "对插件的某些操作失败。有关更多详细信息，请参阅日志文件。\n"
 "{failureMsg}"
 
 #. Translators: Title of message shown when requested action on add-ons failed.
@@ -2194,11 +2191,9 @@ msgstr "未知的命令行参数"
 
 #. Translators: A message informing the user that there are errors in the configuration file.
 #: core.py:162
-msgid ""
-"Your configuration file contains errors. Your configuration has been reset to factory defaults.\n"
+msgid "Your configuration file contains errors. Your configuration has been reset to factory defaults.\n"
 "More details about the errors can be found in the log file."
-msgstr ""
-"您的配置文件包含错误。您的配置已经被重置为默认设置。\n"
+msgstr "您的配置文件包含错误。您的配置已经被重置为默认设置。\n"
 "如需了解错误详细信息，请查看日志文件。"
 
 #. Translators: The title of the dialog to tell users that there are errors in the configuration file.
@@ -2207,11 +2202,9 @@ msgid "Configuration File Error"
 msgstr "配置文件错误"
 
 #: core.py:185
-msgid ""
-"Your gesture map file contains errors.\n"
+msgid "Your gesture map file contains errors.\n"
 "More details about the errors can be found in the log file."
-msgstr ""
-"您的手势映射文件包含错误。\n"
+msgstr "您的手势映射文件包含错误。\n"
 "如果需要了解此错误的详细信息，请查看日志文件。"
 
 #: core.py:188
@@ -3580,11 +3573,9 @@ msgstr "无替换文本"
 #. Translators: Character and its replacement used from the "Review current Symbol" command. Example: "Character: ? Replacement: question"
 #: globalCommands.py:2358
 #, python-brace-format
-msgid ""
-"Character: {character}\n"
+msgid "Character: {character}\n"
 "Replacement: {replacement}"
-msgstr ""
-"符号：{character}\n"
+msgstr "符号：{character}\n"
 "替换文本：{replacement}"
 
 #. Translators: title for expanded symbol dialog. Example: "Expanded symbol (English)"
@@ -7002,8 +6993,7 @@ msgstr "正在检查更新"
 #: updateCheck.py:409
 #, python-brace-format
 msgctxt "updateCheck"
-msgid ""
-"Make sure you are connected to the internet, and the NVDA update mirror URL is valid.\n"
+msgid "Make sure you are connected to the internet, and the NVDA update mirror URL is valid.\n"
 "Mirror URL: {url}"
 msgstr "请检查网络连接，并确保更新镜像网址 {url} 有效。"
 
@@ -7018,11 +7008,9 @@ msgstr "无法连接到 NV Access 服务器。"
 #: updateCheck.py:422
 #, python-brace-format
 msgctxt "updateCheck"
-msgid ""
-"Error checking for update.\n"
+msgid "Error checking for update.\n"
 "{tip}"
-msgstr ""
-"检查更新时出错。\n"
+msgstr "检查更新时出错。\n"
 "{tip}"
 
 #. Translators: The title of the dialog informing the user about an NVDA update.
@@ -7127,14 +7115,12 @@ msgstr "下载更新时出错。"
 
 #. Translators: The message requesting donations from users.
 #: updateCheck.py:939
-msgid ""
-"We need your help in order to continue to improve NVDA.\n"
+msgid "We need your help in order to continue to improve NVDA.\n"
 "This project relies primarily on donations and grants. By donating, you are helping to fund full time development.\n"
 "If even $10 is donated for every download, we will be able to cover all of the ongoing costs of the project.\n"
 "All donations are received by NV Access, the non-profit organisation which develops NVDA.\n"
 "Thank you for your support."
-msgstr ""
-"我们需要您的帮助，以便持续改进 NVDA。\n"
+msgstr "我们需要您的帮助，以便持续改进 NVDA。\n"
 "此项目主要依靠捐赠和资助，您的捐赠将帮助用于全职开发。\n"
 "即使每次下载只有 10 美元的捐赠，我们也能够支付项目的所有持续费用。\n"
 "所有的捐款都由开发 NVDA 的非营利组织 NV Access 接收。\n"
@@ -7173,14 +7159,10 @@ msgstr "不建议在作为被控计算机连接到 NVDA 远程访问时更新 NV
 #. Translators: Message shown to users when attempting to update NVDA from an installed copy
 #. on a computer which is being remotely controlled via NVDA Remote Access.
 #: updateCheck.py:1012
-msgid ""
-"The currently active connection may not be continued during or after the update. Even if the connection is continued, you will be unable to respond to User Account Control (UAC) prompts from the controlling computer. You should only proceed if you have physical access to the controlled computer.\n"
-"\n"
+msgid "The currently active connection may not be continued during or after the update. Even if the connection is continued, you will be unable to respond to User Account Control (UAC) prompts from the controlling computer. You should only proceed if you have physical access to the controlled computer.\n\n"
 "Are you sure you want to continue?"
-msgstr ""
-"更新期间或更新后，当前活动连接可能无法保持。即使连接保持，您也将无法从主控计算机响应用户帐户控制（UAC）提示。\n"
-"仅在您能物理访问被控计算机的情况下才可继续操作。\n"
-"\n"
+msgstr "更新期间或更新后，当前活动连接可能无法保持。即使连接保持，您也将无法从主控计算机响应用户帐户控制（UAC）提示。\n"
+"仅在您能物理访问被控计算机的情况下才可继续操作。\n\n"
 "您确定要继续吗？"
 
 #. Translators: The title of a dialog.
@@ -7213,28 +7195,22 @@ msgstr "NVDA 贡献者版权所有 {years}"
 #. Translators: "About NVDA" dialog box message
 #: versionInfo.py:23
 #, python-brace-format
-msgid ""
-"{longName} ({name})\n"
+msgid "{longName} ({name})\n"
 "Version: {version} ({version_detailed})\n"
 "URL: {url}\n"
-"{copyright}\n"
-"\n"
+"{copyright}\n\n"
 "{name} is covered by the GNU General Public License (Version 2). You are free to share or change this software in any way you like as long as it is accompanied by the license and you make all source code available to anyone who wants it. This applies to both original and modified copies of this software, plus any derivative works.\n"
 "For further details, you can view the license from the Help menu.\n"
-"It can also be viewed online at: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\n"
-"\n"
+"It can also be viewed online at: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\n\n"
 "{name} is developed by NV Access, a non-profit organisation committed to helping and promoting free and open source solutions for blind and vision impaired people.\n"
 "If you find NVDA useful and want it to continue to improve, please consider donating to NV Access. You can do this by selecting Donate from the NVDA menu."
-msgstr ""
-"{longName}（{name}）\n"
+msgstr "{longName}（{name}）\n"
 "版本：{version} ({version_detailed})\n"
 "网址：{url}\n"
-"{copyright}\n"
-"\n"
+"{copyright}\n\n"
 "{name} 遵循 GNU 通用公共授权协议第二版， 您可以自由分享或者以任何方式修改本软件，但在重新发布时必须包含本协议，同时必须公开原版和修改版的源代码，并附上任何用本软件的源代码所产生的软件。\n"
 "关于本授权协议的详情,您可以通过“帮助”菜单的“版权信息”访问。\n"
-"您也可参看以下网页：https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\n"
-"\n"
+"您也可参看以下网页：https://www.gnu.org/licenses/old-licenses/gpl-2.0.html\n\n"
 "{name} 是由非赢利组织“NV Access”开发的一个用于协助视障用户的免费且开放源代码的解决方案。\n"
 "如果您觉得 NVDA 对您很有帮助，并希望它能不断完善，请考虑向 NV Access 捐款。您可通过 NVDA 菜单中的“立即捐赠”选项完成操作。"
 
@@ -7242,11 +7218,9 @@ msgstr ""
 #. from windows explorer and NVDA is not running.
 #: nvda_slave.pyw:115
 #, python-brace-format
-msgid ""
-"Cannot install NVDA add-on from {path}.\n"
+msgid "Cannot install NVDA add-on from {path}.\n"
 "You must be running NVDA to be able to install add-ons."
-msgstr ""
-"无法从 {path} 安装插件。\n"
+msgstr "无法从 {path} 安装插件。\n"
 "您必须先运行 NVDA 以使插件可以顺利的安装。"
 
 #. Translators: A title of the dialog shown when fetching add-on data from the store fails
@@ -7260,8 +7234,7 @@ msgstr "插件数据更新失败"
 #: addonStore\dataManager.py:217
 #, python-brace-format
 msgctxt "addonStore"
-msgid ""
-"Make sure you are connected to the internet, and the Add-on Store mirror URL is valid.\n"
+msgid "Make sure you are connected to the internet, and the Add-on Store mirror URL is valid.\n"
 "Mirror URL: {url}"
 msgstr "请检查网络连接，并确保插件商店镜像网址 {url} 有效。"
 
@@ -7606,8 +7579,7 @@ msgstr "已安装的不兼容插件(&A)"
 #, python-brace-format
 msgctxt "addonStore"
 msgid "An updated version of NVDA is required. NVDA version {nvdaVersion} or later."
-msgstr ""
-"需要更高版本的 NVDA。\n"
+msgstr "需要更高版本的 NVDA。\n"
 "NVDA {nvdaVersion} 或更高。"
 
 #. Translators: The reason an add-on is not compatible.
@@ -7617,8 +7589,7 @@ msgstr ""
 #, python-brace-format
 msgctxt "addonStore"
 msgid "An updated version of this add-on is required. This add-on was last tested with NVDA {lastTestedNVDAVersion}. NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. You can enable this add-on at your own risk. "
-msgstr ""
-"您安装的插件版本太旧，需要更新。\n"
+msgstr "您安装的插件版本太旧，需要更新。\n"
 "该插件已在 NVDA {lastTestedNVDAVersion} 测试。此版本的 NVDA 要求该插件在 {nvdaVersion} 或更高版本的 NVDA 进行测试。\n"
 "您需要自行承担启用该插件的风险。"
 
@@ -7627,8 +7598,7 @@ msgstr ""
 #: addonStore\models\version.py:145
 msgctxt "addonStore"
 msgid "Your NVDA configuration contains add-ons that are incompatible with this version of NVDA. These add-ons will be disabled after installation. After installation, you will be able to manually re-enable these add-ons at your own risk. If you rely on these add-ons, please review the list to decide whether to continue with the installation. "
-msgstr ""
-"您的配置中含有与该版本 NVDA 不兼容的插件。\n"
+msgstr "您的配置中含有与该版本 NVDA 不兼容的插件。\n"
 "NVDA 安装后这些插件会被禁用。安装完成后您可以手动启用这些插件，但需自行承担风险。\n"
 "如果您依赖这些插件，请查看“不兼容的插件”列表以决定是否继续安装。"
 
@@ -11627,8 +11597,7 @@ msgstr "确保您已连接到互联网且网址正确。"
 #: gui\_SetURLDialog.py:209
 #, python-brace-format
 msgid "The URL you have entered failed the connection test. {tip}"
-msgstr ""
-"您输入的网址连接测试失败。\n"
+msgstr "您输入的网址连接测试失败。\n"
 "{tip}"
 
 #. Translators: Reported when last saved configuration has been applied by using revert to saved configuration option in NVDA menu.
@@ -11671,21 +11640,13 @@ msgstr "关于 NVDA"
 
 #. Translators: Explain the COM Registration Fixing tool to users before running
 #: gui\__init__.py:517
-msgid ""
-"Welcome to the COM Registration Fixing tool.\n"
-"\n"
-"Installing and uninstalling programs, as well as other events, can damage accessibility entries in the Windows registry. This can cause previously accessible elements to be presented incorrectly, or can cause \"unknown\" or \"pane\" to be spoken or brailled in some applications or Windows components, instead of the content you were expecting.\n"
-"\n"
-"This tool attempts to fix such common problems. Note that the tool must access the system registry, which requires administrative privileges.\n"
-"\n"
+msgid "Welcome to the COM Registration Fixing tool.\n\n"
+"Installing and uninstalling programs, as well as other events, can damage accessibility entries in the Windows registry. This can cause previously accessible elements to be presented incorrectly, or can cause \"unknown\" or \"pane\" to be spoken or brailled in some applications or Windows components, instead of the content you were expecting.\n\n"
+"This tool attempts to fix such common problems. Note that the tool must access the system registry, which requires administrative privileges.\n\n"
 "Press Continue to run the tool now."
-msgstr ""
-"欢迎使用 COM 注册修复工具。\n"
-"\n"
-"安装或卸载程序及其他事件可能会损坏 Windows 注册表中的辅助功能条目。这可能导致以前可访问的元素显示不正确，或在某些应用程序及 Windows 组件中输出“未知”或“窗格”，而不是您期望的内容。\n"
-"\n"
-"该工具将尝试修复此类常见问题。请注意，该工具必须访问系统注册表，这需要管理员权限。\n"
-"\n"
+msgstr "欢迎使用 COM 注册修复工具。\n\n"
+"安装或卸载程序及其他事件可能会损坏 Windows 注册表中的辅助功能条目。这可能导致以前可访问的元素显示不正确，或在某些应用程序及 Windows 组件中输出“未知”或“窗格”，而不是您期望的内容。\n\n"
+"该工具将尝试修复此类常见问题。请注意，该工具必须访问系统注册表，这需要管理员权限。\n\n"
 "按“继续”立即运行该工具。"
 
 #. Translators: The title of various dialogs displayed when using the COM Registration Fixing tool
@@ -11701,11 +11662,9 @@ msgstr "请稍候，NVDA 正在尝试修复系统中的 COM 注册……"
 #. Translators: message shown to the user on COM Registration Fix fail
 #: gui\__init__.py:584
 #, python-brace-format
-msgid ""
-"The COM Registration Fixing Tool was unsuccessful. This Windows error may provide more information.\n"
+msgid "The COM Registration Fixing Tool was unsuccessful. This Windows error may provide more information.\n"
 "{error}"
-msgstr ""
-"COM 注册修复工具未能成功运行。此 Windows 错误可能提供更多信息。\n"
+msgstr "COM 注册修复工具未能成功运行。此 Windows 错误可能提供更多信息。\n"
 "{error}"
 
 #. Translators: The title of a COM Registration Fixing Tool dialog, when the tool has failed
@@ -11715,8 +11674,7 @@ msgstr "COM 注册修复失败"
 
 #. Translators: Message shown when the COM Registration Fixing tool completes.
 #: gui\__init__.py:595
-msgid ""
-"The COM Registration Fixing Tool has completed successfully.\n"
+msgid "The COM Registration Fixing Tool has completed successfully.\n"
 "It is highly recommended that you restart your computer now, to make sure the changes take full effect."
 msgstr "COM 注册修复工具已完成。强烈建议您现在重新启动计算机，以确保更改完全生效。"
 
@@ -12293,11 +12251,9 @@ msgstr "此配置的使用条件为："
 #. Translators: The confirmation prompt presented when creating a new configuration profile
 #. and the selected trigger is already associated.
 #: gui\configProfiles.py:496
-msgid ""
-"This trigger is already associated with another profile. If you continue, it will be removed from that profile and associated with this one.\n"
+msgid "This trigger is already associated with another profile. If you continue, it will be removed from that profile and associated with this one.\n"
 "Are you sure you want to continue?"
-msgstr ""
-"此关联已经与其他配置连接。如果您继续，旧的配置连接将被此连接替换。\n"
+msgstr "此关联已经与其他配置连接。如果您继续，旧的配置连接将被此连接替换。\n"
 "您希望继续吗？"
 
 #. Translators: An error displayed when the user attempts to create a configuration profile
@@ -12314,11 +12270,9 @@ msgstr "保存配置时发生错误，文件系统可能处于只读状态。"
 #. Translators: The prompt asking the user whether they wish to
 #. manually activate a configuration profile that has just been created.
 #: gui\configProfiles.py:558
-msgid ""
-"To edit this profile, you will need to manually activate it. Once you have finished editing, you will need to manually deactivate it to resume normal usage.\n"
+msgid "To edit this profile, you will need to manually activate it. Once you have finished editing, you will need to manually deactivate it to resume normal usage.\n"
 "Do you wish to manually activate it now?"
-msgstr ""
-"要想编辑此配置，您必须先将其激活。一旦您完成编辑，您必须手动禁用它已使配置恢复到原来的状态。\n"
+msgstr "要想编辑此配置，您必须先将其激活。一旦您完成编辑，您必须手动禁用它已使配置恢复到原来的状态。\n"
 "您希望现在就手动激活它吗？"
 
 #. Translators: The title of the confirmation dialog for manual activation of a created profile.
@@ -12441,14 +12395,10 @@ msgstr "重置(&D)"
 
 #. Translators: A prompt for confirmation to reset all gestures in the Input Gestures dialog.
 #: gui\inputGestures.py:789
-msgid ""
-"Are you sure you want to reset all gestures to their factory defaults?\n"
-"\n"
+msgid "Are you sure you want to reset all gestures to their factory defaults?\n\n"
 "\t\t\tAll of your user defined gestures, whether previously set or defined during this session, will be lost.\n"
 "\t\t\tThis cannot be undone."
-msgstr ""
-"您是否要将所有按键与手势重置为默认值？\n"
-"\n"
+msgstr "您是否要将所有按键与手势重置为默认值？\n\n"
 "\t\t\t重置后，您先前保存和设置的所有按键与手势都将丢失。\n"
 "\t\t\t该操作无法撤销。"
 
@@ -12616,14 +12566,10 @@ msgstr "不建议在作为被控计算机连接到 NVDA 远程访问时安装 NV
 #. Translators: Message shown to users when attempting to install or update NVDA from the launcher
 #. on a computer which is being remotely controlled via NVDA Remote Access
 #: gui\installerGui.py:468
-msgid ""
-"You will be unable to respond to User Account Control (UAC) prompts from the controlling computer. You should only proceed if you have physical access to the controlled computer.\n"
-"\n"
+msgid "You will be unable to respond to User Account Control (UAC) prompts from the controlling computer. You should only proceed if you have physical access to the controlled computer.\n\n"
 "Are you sure you want to continue?"
-msgstr ""
-"您将无法从主控计算机响应用户帐户控制（UAC）提示。\n"
-"仅在您能物理访问被控计算机的情况下才可继续操作。\n"
-"\n"
+msgstr "您将无法从主控计算机响应用户帐户控制（UAC）提示。\n"
+"仅在您能物理访问被控计算机的情况下才可继续操作。\n\n"
 "您确定要继续吗？"
 
 #. Translators: The title of the Create Portable NVDA dialog.
@@ -12789,14 +12735,10 @@ msgstr "默认（{default}）"
 #. Translators: Content of the message displayed when a validation error occurs in the settings dialog
 #: gui\settingsDialogs.py:444
 #, python-brace-format
-msgid ""
-"{message}\n"
-"\n"
+msgid "{message}\n\n"
 "Category: \"{category}\"\n"
 "Option: \"{option}\""
-msgstr ""
-"“{option}”提示“{message}”\n"
-"\n"
+msgstr "“{option}”提示“{message}”\n\n"
 "该选项位于“{category}”类别下。"
 
 #. Translators: The title of the message box when a setting's configuration is not valid.
@@ -13131,8 +13073,7 @@ msgstr "移动光标后读出字符解释(&D)"
 #. Translators: Warning shown when 'talk' speech mode is disabled in settings.
 #: gui\settingsDialogs.py:1974
 msgid "You did not choose Talk as one of your speech mode options. Please note that this may result in no speech output at all. Are you sure you want to continue?"
-msgstr ""
-"您将取消“正常朗读”作为可切换的语音模式之一。\n"
+msgstr "您将取消“正常朗读”作为可切换的语音模式之一。\n"
 "请注意，这可能导致没有语音输出。\n"
 "您确定要继续吗？"
 
@@ -13922,14 +13863,10 @@ msgstr "删除所有已信任的指纹"
 #. Translators: This message is presented when the user tries to delete all stored trusted fingerprints.
 #: gui\settingsDialogs.py:3574
 msgctxt "remote"
-msgid ""
-"This will cause NVDA to forget all previously trusted Remote Access servers. When connecting to a previously trusted unrecognised server, you will again be asked whether to trust its certificate.\n"
-"\n"
+msgid "This will cause NVDA to forget all previously trusted Remote Access servers. When connecting to a previously trusted unrecognised server, you will again be asked whether to trust its certificate.\n\n"
 "Are you sure you want to continue?"
-msgstr ""
-"这将导致 NVDA 忘记所有之前受信任的远程访问服务器。\n"
-"当连接到之前受信任但未经验证的服务器时，系统将再次询问是否信任其证书。\n"
-"\n"
+msgstr "这将导致 NVDA 忘记所有之前受信任的远程访问服务器。\n"
+"当连接到之前受信任但未经验证的服务器时，系统将再次询问是否信任其证书。\n\n"
 "您确定要继续吗？"
 
 #. Translators: This is the title of the dialog presented when the user tries to delete all stored trusted fingerprints.
@@ -14107,11 +14044,9 @@ msgstr "旧版"
 #. Note the '\n' is used to split this long label approximately in half.
 #: gui\settingsDialogs.py:3874
 msgctxt "advanced.uiaWithChromium"
-msgid ""
-"Use UIA with Microsoft Edge and other \n"
+msgid "Use UIA with Microsoft Edge and other \n"
 "&Chromium based browsers when available:"
-msgstr ""
-"在 Microsoft Edge 及其他基于 Chromium 内核的浏览器中\n"
+msgstr "在 Microsoft Edge 及其他基于 Chromium 内核的浏览器中\n"
 "启用 UIA 接口（如果可用）(&C)："
 
 #. Translators: Label for the default value of the Use UIA with Chromium combobox,
@@ -14338,8 +14273,7 @@ msgstr "警告！"
 #. Translators: This is a label appearing on the Advanced settings panel.
 #: gui\settingsDialogs.py:4363
 msgid "The following settings are for advanced users. Changing them may cause NVDA to function incorrectly. Please only change these if you know what you are doing or have been specifically instructed by NVDA developers."
-msgstr ""
-"以下设置适用于高级用户,修改这些设置可能会导致 NVDA 无法正常运行。\n"
+msgstr "以下设置适用于高级用户,修改这些设置可能会导致 NVDA 无法正常运行。\n"
 "只有在清楚要更改选项的含义、或在 NVDA 开发者的指导下，才可进行修改。"
 
 #. Translators: This is the label for a checkbox in the Advanced settings panel.
@@ -14514,11 +14448,9 @@ msgstr "无法加载 {providerName} 视觉增强提供程序"
 #. load multiple vision enhancement providers.
 #: gui\settingsDialogs.py:5124
 #, python-brace-format
-msgid ""
-"Could not load the following vision enhancement providers:\n"
+msgid "Could not load the following vision enhancement providers:\n"
 "{providerNames}"
-msgstr ""
-"无法加载以下视觉增强提供程序：\n"
+msgstr "无法加载以下视觉增强提供程序：\n"
 "{providerNames}"
 
 #. Translators: The title of the vision enhancement provider error message box.
@@ -14537,11 +14469,9 @@ msgstr "无法正常终止 {providerName} 视觉增强提供程序"
 #. NVDA is unable to terminate multiple vision enhancement providers.
 #: gui\settingsDialogs.py:5155
 #, python-brace-format
-msgid ""
-"Could not gracefully terminate the following vision enhancement providers:\n"
+msgid "Could not gracefully terminate the following vision enhancement providers:\n"
 "{providerNames}"
-msgstr ""
-"无法正常终止以下视觉增强提供程序：\n"
+msgstr "无法正常终止以下视觉增强提供程序：\n"
 "{providerNames}"
 
 #. Translators: This is a label appearing on the vision settings panel.
@@ -14790,14 +14720,12 @@ msgstr "临时字典"
 
 #. Translators: The main message for the Welcome dialog when the user starts NVDA for the first time.
 #: gui\startupDialogs.py:38
-msgid ""
-"Most commands for controlling NVDA require you to hold down the NVDA key while pressing other keys.\n"
+msgid "Most commands for controlling NVDA require you to hold down the NVDA key while pressing other keys.\n"
 "By default, the Insert and numpad Insert keys may both be used as the NVDA key.\n"
 "You can also configure NVDA to use the CapsLock as the NVDA key.\n"
 "Press NVDA+n at any time to activate the NVDA menu.\n"
 "From this menu, you can configure NVDA, get help, and access other NVDA functions."
-msgstr ""
-"大多数控制 NVDA 的命令要求您在按住 NVDA 键的同时按其他键。\n"
+msgstr "大多数控制 NVDA 的命令要求您在按住 NVDA 键的同时按其他键。\n"
 "默认情况下，主键盘和数字键盘的插入键都可以用作 NVDA 键。\n"
 "您还可以将 NVDA 配置为使用大写锁定键作为 NVDA 键。\n"
 "随时可按 NVDA+n 激活 NVDA 菜单。\n"
@@ -14867,14 +14795,10 @@ msgstr "NVDA 使用数据收集"
 
 #. Translators: A message asking the user if they want to allow usage stats gathering
 #: gui\startupDialogs.py:282
-msgid ""
-"In order to improve NVDA in the future, NV Access wishes to collect usage data from running copies of NVDA.\n"
-"\n"
-"Data includes Operating System version, NVDA version, language, country of origin, plus certain NVDA configuration such as current synthesizer, braille display and braille table. No spoken or braille content will be ever sent to NV Access. Please refer to the User Guide for a current list of all data collected.\n"
-"\n"
+msgid "In order to improve NVDA in the future, NV Access wishes to collect usage data from running copies of NVDA.\n\n"
+"Data includes Operating System version, NVDA version, language, country of origin, plus certain NVDA configuration such as current synthesizer, braille display and braille table. No spoken or braille content will be ever sent to NV Access. Please refer to the User Guide for a current list of all data collected.\n\n"
 "Do you wish to allow NV Access to periodically collect this data in order to improve NVDA?"
-msgstr ""
-"为了在未来改进 NVDA，NV Access 希望从正在运行的 NVDA 副本收集使用数据。\n"
+msgstr "为了在未来改进 NVDA，NV Access 希望从正在运行的 NVDA 副本收集使用数据。\n"
 "数据包括操作系统版本、NVDA 版本、语言、所在国家/地区、以及某些 NVDA 配置，如语音合成器，盲文点显器和盲文表等。\n"
 "NVDA 不会将语音或盲文内容发送给 NV Access。\n"
 "关于收集数据的完整列表，请参阅用户指南的数据收集部分。\n"
@@ -15117,11 +15041,9 @@ msgstr "记住此选择"
 #: gui\addonStoreGui\controls\messageDialogs.py:118
 #, python-brace-format
 msgctxt "addonStore"
-msgid ""
-"Warning: add-on installation may result in downgrade: {name}. The installed add-on version cannot be compared with the add-on store version. Installed version: {oldVersion}. Available version: {version}.\n"
+msgid "Warning: add-on installation may result in downgrade: {name}. The installed add-on version cannot be compared with the add-on store version. Installed version: {oldVersion}. Available version: {version}.\n"
 "Proceed with installation anyway? "
-msgstr ""
-"警告：安装 {name} 可能会导致降级。无法将已安装的插件版本与插件商店的版本进行比较。已安装版本：{oldVersion}。可安装版本：{version}。\n"
+msgstr "警告：安装 {name} 可能会导致降级。无法将已安装的插件版本与插件商店的版本进行比较。已安装版本：{oldVersion}。可安装版本：{version}。\n"
 "您仍要安装该插件吗？"
 
 #. Translators: The title of a dialog presented when an error occurs.
@@ -15150,11 +15072,9 @@ msgstr "移除插件"
 #: gui\addonStoreGui\controls\messageDialogs.py:174
 #, python-brace-format
 msgctxt "addonStore"
-msgid ""
-"Warning: add-on is incompatible: {name} {version}. Check for an updated version of this add-on if possible. This add-on was last tested with NVDA {lastTestedNVDAVersion}. NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. Installation may cause unstable behavior in NVDA.\n"
+msgid "Warning: add-on is incompatible: {name} {version}. Check for an updated version of this add-on if possible. This add-on was last tested with NVDA {lastTestedNVDAVersion}. NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. Installation may cause unstable behavior in NVDA.\n"
 "Proceed with installation anyway? "
-msgstr ""
-"警告：插件不兼容：{name}-{version}。如果可能，请检查该插件有无新版本。\n"
+msgstr "警告：插件不兼容：{name}-{version}。如果可能，请检查该插件有无新版本。\n"
 "该插件已在 NVDA {lastTestedNVDAVersion} 测试。此版本的 NVDA 要求该插件在 {nvdaVersion} 或更高版本的 NVDA 进行测试。\n"
 "安装该插件可能会导致 NVDA 不稳定或无法正常运行。是否仍要安装？"
 
@@ -15163,11 +15083,9 @@ msgstr ""
 #: gui\addonStoreGui\controls\messageDialogs.py:207
 #, python-brace-format
 msgctxt "addonStore"
-msgid ""
-"Warning: add-on is incompatible: {name} {version}. Check for an updated version of this add-on if possible. This add-on was last tested with NVDA {lastTestedNVDAVersion}. NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. Enabling may cause unstable behavior in NVDA.\n"
+msgid "Warning: add-on is incompatible: {name} {version}. Check for an updated version of this add-on if possible. This add-on was last tested with NVDA {lastTestedNVDAVersion}. NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. Enabling may cause unstable behavior in NVDA.\n"
 "Proceed with enabling anyway? "
-msgstr ""
-"警告：插件不兼容：{name}-{version}。如果可能，请检查该插件有无新版本。\n"
+msgstr "警告：插件不兼容：{name}-{version}。如果可能，请检查该插件有无新版本。\n"
 "该插件已在 NVDA {lastTestedNVDAVersion} 测试。此版本的 NVDA 要求该插件在 {nvdaVersion} 或更高版本的 NVDA 进行测试。\n"
 "启用该插件可能会导致 NVDA 不稳定或无法正常运行。是否仍要启用？"
 
@@ -15193,12 +15111,10 @@ msgstr "插件安装失败"
 #. Translators: A message asking the user if they really wish to install an addon.
 #: gui\addonStoreGui\controls\messageDialogs.py:263
 #, python-brace-format
-msgid ""
-"Are you sure you want to install this add-on?\n"
+msgid "Are you sure you want to install this add-on?\n"
 "Only install add-ons from trusted sources.\n"
 "Addon: {summary} {version}"
-msgstr ""
-"您确定要安装此插件吗？\n"
+msgstr "您确定要安装此插件吗？\n"
 "请注意，仅安装来自可信来源的插件。\n"
 "插件: {summary} {version}"
 
@@ -15212,12 +15128,10 @@ msgstr "插件安装"
 #: gui\addonStoreGui\controls\messageDialogs.py:287
 #, python-brace-format
 msgctxt "addonStore"
-msgid ""
-"{summary} ({name})\n"
+msgid "{summary} ({name})\n"
 "Version: {version}\n"
 "Description: {description}\n"
-msgstr ""
-"{summary} ({name})\n"
+msgstr "{summary} ({name})\n"
 "版本：{version}\n"
 "描述：{description}\n"
 
@@ -18597,12 +18511,9 @@ msgstr "开启黑屏时播放声音(&P)"
 #. Translators: A warning shown when activating the screen curtain.
 #. the translation of "Screen Curtain" should match the "translated name"
 #: visionEnhancementProviders\screenCurtain.py:137
-msgid ""
-"Enabling Screen Curtain will make the screen of your computer completely black. Ensure you will be able to navigate without any use of your screen before continuing. \n"
-"\n"
+msgid "Enabling Screen Curtain will make the screen of your computer completely black. Ensure you will be able to navigate without any use of your screen before continuing. \n\n"
 "Do you wish to continue?"
-msgstr ""
-"开启黑屏将使计算机的屏幕完全变黑。在继续操作之前，请确保无需使用屏幕即可进行浏览。\n"
+msgstr "开启黑屏将使计算机的屏幕完全变黑。在继续操作之前，请确保无需使用屏幕即可进行浏览。\n"
 "您想继续吗？"
 
 #. Translators: option to enable screen curtain in the vision settings panel
@@ -18773,8 +18684,7 @@ msgstr "控制远程计算机"
 #, python-brace-format
 msgctxt "remote"
 msgid "Do you wish to control the computer on server {server} with key {key}?"
-msgstr ""
-"您要控制远程计算机嗎？\n"
+msgstr "您要控制远程计算机嗎？\n"
 "服务器: {server}，秘钥: {key}"
 
 #. Translators: Ask the user if they want to allow the remote computer to control this computer.
@@ -18782,8 +18692,7 @@ msgstr ""
 #, python-brace-format
 msgctxt "remote"
 msgid "Do you wish to allow this computer to be controlled on server {server} with key {key}?"
-msgstr ""
-"您要允许此计算机被控制吗？\n"
+msgstr "您要允许此计算机被控制吗？\n"
 "服务器: {server}，秘钥: {key}"
 
 #. Translators: Title of the connection request dialog.
@@ -18917,20 +18826,13 @@ msgstr "安全警告"
 #: _remoteClient\dialogs.py:485
 #, python-brace-format
 msgctxt "remote"
-msgid ""
-"The certificate of this server could not be verified. Using the wrong fingerprint may allow a third party to access the Remote Access session.\n"
-"\n"
+msgid "The certificate of this server could not be verified. Using the wrong fingerprint may allow a third party to access the Remote Access session.\n\n"
 "Before continuing, please make sure that the following server certificate fingerprint is correct.\n"
-"Server SHA256 fingerprint: {fingerprint}\n"
-"\n"
+"Server SHA256 fingerprint: {fingerprint}\n\n"
 "Continue connecting anyway?"
-msgstr ""
-"该服务器的证书无法验证。使用错误的指纹可能会允许第三方访问远程访问会话。\n"
-"\n"
-"在继续之前，请确保以下服务器证书指纹正确。\n"
-"\n"
-"服务器 SHA256 指纹： {fingerprint}\n"
-"\n"
+msgstr "该服务器的证书无法验证。使用错误的指纹可能会允许第三方访问远程访问会话。\n\n"
+"在继续之前，请确保以下服务器证书指纹正确。\n\n"
+"服务器 SHA256 指纹： {fingerprint}\n\n"
 "您仍要继续连接吗？"
 
 #. Translators: A button to connect and remember the server with unauthorized certificate.
@@ -19046,3 +18948,4 @@ msgstr "来自远程访问服务器的消息"
 msgctxt "remote"
 msgid "Remote NVDA not connected"
 msgstr "远程 NVDA 未连接"
+

--- a/Translation/user_docs/changes.xliff
+++ b/Translation/user_docs/changes.xliff
@@ -5880,7 +5880,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>In terminal programs on Windows 10 version 1607 and later, the calculation of changed text now runs within NVDA instead of via an external process, which may improve performance and reliability. (#18480, @codeofdusk)</source>
-        <target>在 Windows 10 版本 1607 及更高版本的终端程序中，更改文本的计算现在在 NVDA 内部运行，而不是通过外部进程，这可能会提高性能和可靠性。(#18480, @codeofdusk)</target>
+        <target>在 Windows 10 版本 1607 及更高版本的终端程序中，变更文本的计算现在在 NVDA 内部运行，而不是通过外部进程，这可能会提高性能和可靠性。(#18480, @codeofdusk)</target>
       </segment>
     </unit>
     <unit id="e3eebd76-4540-4cce-99b4-741e78fc67bb">
@@ -5890,7 +5890,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>The NVDA Remote Access connection dialog now remembers the most recent connection mode, server type and locally hosted port of manual connections. (#18512, #18701)</source>
-        <target>远程访问的连接到另一台计算机对话框现会记住上次手动连接时所选的模式、服务器类型和本地托管端口。(#18512, #18701)</target>
+        <target>远程访问的“连接到另一台计算机”对话框现会记住上次手动连接时所选的模式、服务器类型和本地托管端口。(#18512, #18701)</target>
       </segment>
     </unit>
     <unit id="9ff079b7-a64e-4b66-940a-767f60586c07">
@@ -5900,7 +5900,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Bug Fixes</source>
-        <target>错误 修复</target>
+        <target>错误修复</target>
       </segment>
     </unit>
     <unit id="23c98fc5-e388-4f48-9a82-9bba110c309a">
@@ -6000,7 +6000,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Fixed support for paragraph mouse text unit in Java applications. (#18231, @hwf1324)</source>
-        <target>修复了 Java 应用程序中段落鼠标文本单元的支持问题。(#18231, @hwf1324)</target>
+        <target>修复了 Java 应用程序中段落鼠标文本单元的支持。(#18231, @hwf1324)</target>
       </segment>
     </unit>
     <unit id="0f352991-347e-4bef-9619-1d4cec4f1d6c">
@@ -6119,7 +6119,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)</source>
-        <target>对于 `IAccessible` 对象，其 `flowsFrom` 和 `flowsTo` 属性现在会对 MSAA (非 IA2) 对象抛出 `NotImplementedError`。(#18416, @LeonarddeR)</target>
+        <target>对于 `IAccessible` 对象，其 `flowsFrom` 和 `flowsTo` 属性现在会对 MSAA（非 IA2）对象抛出 `NotImplementedError`。(#18416, @LeonarddeR)</target>
       </segment>
     </unit>
     <unit id="5220ddaf-59ce-456b-9b8b-f66200103cd6">
@@ -6169,7 +6169,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>The following symbols in `synthDrivers.sapi5` are deprecated with no replacement: (#18300, @gexgd0419)</source>
-        <target>`synthDrivers.sapi5` 中的以下符号已弃用且无替代方案： (#18300, @gexgd0419)</target>
+        <target>`synthDrivers.sapi5` 中的以下符号已弃用且无替代方案：(#18300, @gexgd0419)</target>
       </segment>
     </unit>
     <unit id="5c310bc4-28cc-41c5-ac06-a04d360ad922">

--- a/Translation/user_docs/changes.xliff
+++ b/Translation/user_docs/changes.xliff
@@ -6117,7 +6117,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 72</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)</source>
         <target>对于 `IAccessible` 对象，其 `flowsFrom` 和 `flowsTo` 属性现在会对 MSAA (非 IA2) 对象抛出 `NotImplementedError`。(#18416, @LeonarddeR)</target>
       </segment>
@@ -6127,7 +6127,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 73</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>The `nvda_dmp` utility has been removed. (#18480, @codeofdusk)</source>
         <target>移除了 `nvda_dmp` 程序。(#18480, @codeofdusk)</target>
       </segment>
@@ -6137,7 +6137,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 74</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>`comInterfaces_sconscript` has been updated to make the generated files in `comInterfaces` work better with IDEs. (#17608, @gexgd0419)</source>
         <target>更新了 `comInterfaces_sconscript`，使其在 `comInterfaces` 中生成的文件能更好地用于 IDE。(#17608, @gexgd0419)</target>
       </segment>
@@ -6147,7 +6147,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 75</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>NVDA now configures `wx.lib.agw.persist.PersistenceManager` on GUI initialisation. (#18601)</source>
         <target>NVDA 现在会在 GUI 初始化时配置 `wx.lib.agw.persist.PersistenceManager`。(#18601)</target>
       </segment>
@@ -6167,7 +6167,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 79</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>The following symbols in `synthDrivers.sapi5` are deprecated with no replacement: (#18300, @gexgd0419)</source>
         <target>`synthDrivers.sapi5` 中的以下符号已弃用且无替代方案： (#18300, @gexgd0419)</target>
       </segment>
@@ -6177,7 +6177,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 80</note>
         <note appliesTo="source">prefix:   * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>`LP_c_ubyte`</source>
         <target>`LP_c_ubyte`</target>
       </segment>
@@ -6187,7 +6187,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 81</note>
         <note appliesTo="source">prefix:   * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>`LP_c_ulong`</source>
         <target>`LP_c_ulong`</target>
       </segment>
@@ -6197,7 +6197,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 82</note>
         <note appliesTo="source">prefix:   * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>`LP__ULARGE_INTEGER`</source>
         <target>`LP__ULARGE_INTEGER`</target>
       </segment>
@@ -6207,7 +6207,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 83</note>
         <note appliesTo="source">prefix:   * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>`SynthDriver.isSpeaking`</source>
         <target>`SynthDriver.isSpeaking`</target>
       </segment>
@@ -6217,7 +6217,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 84</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>`easeOfAccess.RegistryKey` and `config.RegistryKey` is deprecated, use `config.registry.RegistryKey` instead. (#18608)</source>
         <target>`easeOfAccess.RegistryKey` 和 `config.RegistryKey` 已弃用，请改用 `config.registry.RegistryKey`。(#18608)</target>
       </segment>
@@ -6227,7 +6227,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 85</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>Importing `DEFAULT_EXTENSIONS` from `md2html` is deprecated.</source>
         <target>从 `md2html` 导入 `DEFAULT_EXTENSIONS` 的做法已弃用。</target>
       </segment>
@@ -6236,7 +6236,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       <notes>
         <note appliesTo="source">line: 86</note>
       </notes>
-      <segment state="translated">
+      <segment state="final">
         <source>Importing from `md2html` is discouraged. (#18638)</source>
         <target>不建议从 `md2html` 导入。</target>
       </segment>

--- a/Translation/user_docs/changes.xliff
+++ b/Translation/user_docs/changes.xliff
@@ -6117,9 +6117,9 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 72</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)</source>
-        <target>For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)</target>
+        <target>对于 `IAccessible` 对象，其 `flowsFrom` 和 `flowsTo` 属性现在会对 MSAA (非 IA2) 对象抛出 `NotImplementedError`。(#18416, @LeonarddeR)</target>
       </segment>
     </unit>
     <unit id="5220ddaf-59ce-456b-9b8b-f66200103cd6">
@@ -6127,9 +6127,9 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 73</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>The `nvda_dmp` utility has been removed. (#18480, @codeofdusk)</source>
-        <target>The `nvda_dmp` utility has been removed. (#18480, @codeofdusk)</target>
+        <target>移除了 `nvda_dmp` 程序。(#18480, @codeofdusk)</target>
       </segment>
     </unit>
     <unit id="f61e9244-0d56-46b9-ab2a-b0fedd95be66">
@@ -6137,9 +6137,9 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 74</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>`comInterfaces_sconscript` has been updated to make the generated files in `comInterfaces` work better with IDEs. (#17608, @gexgd0419)</source>
-        <target>`comInterfaces_sconscript` has been updated to make the generated files in `comInterfaces` work better with IDEs. (#17608, @gexgd0419)</target>
+        <target>更新了 `comInterfaces_sconscript`，使其在 `comInterfaces` 中生成的文件能更好地用于 IDE。(#17608, @gexgd0419)</target>
       </segment>
     </unit>
     <unit id="b60467e9-5440-4043-90f5-790987742f63">
@@ -6147,9 +6147,9 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 75</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>NVDA now configures `wx.lib.agw.persist.PersistenceManager` on GUI initialisation. (#18601)</source>
-        <target>NVDA now configures `wx.lib.agw.persist.PersistenceManager` on GUI initialisation. (#18601)</target>
+        <target>NVDA 现在会在 GUI 初始化时配置 `wx.lib.agw.persist.PersistenceManager`。(#18601)</target>
       </segment>
     </unit>
     <unit id="5cbceb29-4c2d-4866-9394-f7d823750eab">
@@ -6167,9 +6167,9 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 79</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>The following symbols in `synthDrivers.sapi5` are deprecated with no replacement: (#18300, @gexgd0419)</source>
-        <target>The following symbols in `synthDrivers.sapi5` are deprecated with no replacement: (#18300, @gexgd0419)</target>
+        <target>`synthDrivers.sapi5` 中的以下符号已弃用且无替代方案： (#18300, @gexgd0419)</target>
       </segment>
     </unit>
     <unit id="5c310bc4-28cc-41c5-ac06-a04d360ad922">
@@ -6177,7 +6177,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 80</note>
         <note appliesTo="source">prefix:   * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>`LP_c_ubyte`</source>
         <target>`LP_c_ubyte`</target>
       </segment>
@@ -6187,7 +6187,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 81</note>
         <note appliesTo="source">prefix:   * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>`LP_c_ulong`</source>
         <target>`LP_c_ulong`</target>
       </segment>
@@ -6197,7 +6197,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 82</note>
         <note appliesTo="source">prefix:   * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>`LP__ULARGE_INTEGER`</source>
         <target>`LP__ULARGE_INTEGER`</target>
       </segment>
@@ -6207,7 +6207,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 83</note>
         <note appliesTo="source">prefix:   * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>`SynthDriver.isSpeaking`</source>
         <target>`SynthDriver.isSpeaking`</target>
       </segment>
@@ -6217,9 +6217,9 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 84</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>`easeOfAccess.RegistryKey` and `config.RegistryKey` is deprecated, use `config.registry.RegistryKey` instead. (#18608)</source>
-        <target>`easeOfAccess.RegistryKey` and `config.RegistryKey` is deprecated, use `config.registry.RegistryKey` instead. (#18608)</target>
+        <target>`easeOfAccess.RegistryKey` 和 `config.RegistryKey` 已弃用，请改用 `config.registry.RegistryKey`。(#18608)</target>
       </segment>
     </unit>
     <unit id="bb747d9e-5d1e-48d2-84f5-89c96d755a00">
@@ -6227,18 +6227,18 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
         <note appliesTo="source">line: 85</note>
         <note appliesTo="source">prefix: * </note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>Importing `DEFAULT_EXTENSIONS` from `md2html` is deprecated.</source>
-        <target>Importing `DEFAULT_EXTENSIONS` from `md2html` is deprecated.</target>
+        <target>从 `md2html` 导入 `DEFAULT_EXTENSIONS` 的做法已弃用。</target>
       </segment>
     </unit>
     <unit id="ffdab4b2-5995-42fb-9165-ca254496befd">
       <notes>
         <note appliesTo="source">line: 86</note>
       </notes>
-      <segment state="initial">
+      <segment state="translated">
         <source>Importing from `md2html` is discouraged. (#18638)</source>
-        <target>Importing from `md2html` is discouraged. (#18638)</target>
+        <target>不建议从 `md2html` 导入。</target>
       </segment>
     </unit>
     <unit id="58b2f98c-6705-4ac1-b96c-34020c02e46f">

--- a/Translation/user_docs/changes.xliff
+++ b/Translation/user_docs/changes.xliff
@@ -7140,7 +7140,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Microsoft Office and LibreOffice support has improved, notably with more shortcuts being announced.</source>
-        <target>一如既往的对 Microsoft Office 和 LibreOffice 进行了改进，本版支持读出更多快捷键的操作结果。</target>
+        <target>一如既往地对 Microsoft Office 和 LibreOffice 进行了改进，本版支持读出更多快捷键的操作结果。</target>
       </segment>
     </unit>
     <unit id="46779647-e748-481d-bf67-387ba5a41f24">
@@ -12471,7 +12471,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>eSpeak-NG, LibLouis braille translator, and Unicode CLDR have been updated.</source>
-        <target>如你所知，我们一如既往的对 eSpeak-NG 语音合成器、LibLouis 盲文翻译器和 Unicode CLDR 进行了更新。</target>
+        <target>如你所知，我们一如既往地对 eSpeak-NG 语音合成器、LibLouis 盲文翻译器和 Unicode CLDR 进行了更新。</target>
       </segment>
     </unit>
     <unit id="303df0a0-8919-4a82-8254-185cc9fb0234">
@@ -15305,7 +15305,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>When the text in a terminal changes without updating the caret, the text on a braille display will now properly update when positioned on a changed line.</source>
-        <target>当终端中的文本改变而系统插入福未更新时，会在盲文点显器上体现文本更新。</target>
+        <target>当终端中的文本改变而系统插入符未更新时，会在盲文点显器上体现文本更新。</target>
       </segment>
     </unit>
     <unit id="a3ad23df-2f51-430b-a128-79afe10ef11e">
@@ -15923,7 +15923,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>eSpeak-NG, LibLouis braille translator, and Unicode CLDR have been updated.</source>
-        <target>一如既往的对 eSpeak-NG、LibLouis 盲文翻译器和 Unicode CLDR 等第三方组件进行了常规更新。</target>
+        <target>一如既往地对 eSpeak-NG、LibLouis 盲文翻译器和 Unicode CLDR 等第三方组件进行了常规更新。</target>
       </segment>
     </unit>
     <unit id="4f69cbc6-7b6d-4f14-8635-48ca6a22b524">
@@ -16172,7 +16172,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Added gestures for Tivomatic Caiku Albatross braille displays. (#14844, #15002)</source>
-        <target>为 Tivomatic Caiku Albatross 点显器添加了下列首饰。(#14844, #15002)</target>
+        <target>为 Tivomatic Caiku Albatross 点显器添加了下列手势。(#14844, #15002)</target>
       </segment>
     </unit>
     <unit id="9b9503ed-d692-48fc-9193-3b887c928691">
@@ -18490,7 +18490,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>`noMessageTimeout` has been removed, replaced by a value for `showMessages`.</source>
-        <target>`noMessageTimeout` 已经被移除，代替他的是一个 `showMessages` 的值。</target>
+        <target>`noMessageTimeout` 已经被移除，代替它的是一个 `showMessages` 的值。</target>
       </segment>
     </unit>
     <unit id="991c9517-9dd9-44be-8d73-ca880d6c5779">
@@ -18984,7 +18984,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>eSpeak has been updated and LibLouis has been updated.</source>
-        <target>一如既往的对 eSpeak 和 LibLouis 进行了更新。</target>
+        <target>一如既往地对 eSpeak 和 LibLouis 进行了更新。</target>
       </segment>
     </unit>
     <unit id="5485ae63-4af7-4825-9bca-572769fd618b">
@@ -20053,7 +20053,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>eSpeak has been updated, which introduces 3 new languages: Belarusian, Luxembourgish and Totontepec Mixe.</source>
-        <target>eSpeak 又一次得到了更新， 新版的 eSpeak 引入了三种新的语言： 白俄罗斯与、卢森堡语和混合海地克里奥尔语。</target>
+        <target>eSpeak 又一次得到了更新， 新版的 eSpeak 引入了三种新的语言： 白俄罗斯语、卢森堡语和混合海地克里奥尔语。</target>
       </segment>
     </unit>
     <unit id="d647b641-8956-4b03-b546-9ffd488e0c4f">
@@ -20262,7 +20262,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Adobe Acrobat / Reader 64 bit will no longer crash when reading a PDF document. (#12920)</source>
-        <target>使用 Adobe Acrobat / Reader 64 阅读 PDF 文档时不在崩溃。(#12920)</target>
+        <target>使用 Adobe Acrobat / Reader 64 阅读 PDF 文档时不再崩溃。(#12920)</target>
       </segment>
     </unit>
     <unit id="b2ee08be-cb8a-4138-ab36-0a45bb69e486">
@@ -20331,7 +20331,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>When rate boost is off, eSpeak's rate does not drop anymore between rates 99% and 100%. (#13876)</source>
-        <target>eSpeapk 的语速加倍关闭后，语速的下降不会在 99% 和 100% 之间横跳。(#13876)</target>
+        <target>eSpeak 的语速加倍关闭后，语速的下降不会在 99% 和 100% 之间横跳。(#13876)</target>
       </segment>
     </unit>
     <unit id="5abd98e0-165f-4b9f-9cf9-24adf85cf77c">
@@ -21938,7 +21938,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Added commands for toggling multiple modifiers simultaneously with a Braille display (#13152)</source>
-        <target>增加了一组在盲文键盘上模拟按下货放开多个修饰键的命令。(#13152)</target>
+        <target>增加了一组在盲文键盘上模拟按下或放开多个修饰键的命令。(#13152)</target>
       </segment>
     </unit>
     <unit id="af0f5f29-c81d-41e2-a0c6-d5e1d3112c21">
@@ -22008,7 +22008,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Espeak-ng has been updated to 1.51-dev commit `7e5457f91e10`. (#12950)</source>
-        <target>Espeak-ng 升级至 1.51-dev commit `7e5457f91e10`。(#12950)</target>
+        <target>Espeak-NG 升级至 1.51-dev commit `7e5457f91e10`。(#12950)</target>
       </segment>
     </unit>
     <unit id="a6a0a081-2ef0-42d3-8049-346bd69ec372">
@@ -22108,7 +22108,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>"Baseline" is no longer reported via the report text formatting command (`NVDA+f`). (#11815)</source>
-        <target>不在通过读出文本格式的命令（`NVDA+f`）读出“基准线”。(#11815)</target>
+        <target>不再通过读出文本格式的命令（`NVDA+f`）读出“基准线”。(#11815)</target>
       </segment>
     </unit>
     <unit id="d9f7ab57-0784-41b4-b091-9fad86b8db43">
@@ -22118,7 +22118,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Activate long description no longer has a default gesture assigned. (#13380)</source>
-        <target>不在默认分配读出长描述的手势。(#13380)</target>
+        <target>不再默认分配读出长描述的手势。(#13380)</target>
       </segment>
     </unit>
     <unit id="de905ab9-15f3-4af0-935c-6754d23eb34d">
@@ -22288,7 +22288,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>HID braille: chorded gestures (e.g. `space+dot4`) can be successfully performed from the Braille display. (#13326)</source>
-        <target>HID 盲文设备：能够通过盲文点显器键入（诸如`空格键+第4点`）这类组合件，并成功实现相应功能。(#13326)</target>
+        <target>HID 盲文设备：能够通过盲文点显器键入（诸如`空格键+第4点`）这类组合键，并成功实现相应功能。(#13326)</target>
       </segment>
     </unit>
     <unit id="4afb8af8-f105-4350-b8ef-80ef8a0164fe">
@@ -22646,7 +22646,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>This ensures code will honor the Windows user setting for swapping the primary mouse button. (#12642)</source>
-        <target>这确保代码能够将更换鼠标主要案件的权限下放给 Windows 用户。(#12642)</target>
+        <target>这确保代码能够将更换鼠标主要按键的权限下放给 Windows 用户。(#12642)</target>
       </segment>
     </unit>
     <unit id="ee6ea0b4-2379-42da-bef8-0fae8e011006">
@@ -23684,7 +23684,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Espeak-ng has been updated to 1.51-dev commit `74068b91bcd578bd7030a7a6cde2085114b79b44`. (#12665)</source>
-        <target>将 Espeak-ng 更新至 1.51-dev commit `74068b91bcd578bd7030a7a6cde2085114b79b44`. (#12665)</target>
+        <target>将 Espeak-NG 更新至 1.51-dev commit `74068b91bcd578bd7030a7a6cde2085114b79b44`. (#12665)</target>
       </segment>
     </unit>
     <unit id="d038232d-7518-44fb-96d6-259693c5c091">
@@ -23983,7 +23983,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>When using a Chinese input method such as Taiwan - Microsoft Quick in Microsoft Word, scrolling the braille display forward and backward no longer incorrectly keeps jumping back to the original caret position. (#12855)</source>
-        <target>休复了在 Word 中使用中文输入法（例如微软拼音）时，向前 / 向后滚动盲文显示，会始终跳回原来输入光标位置的问题。(#12855)</target>
+        <target>修复了在 Word 中使用中文输入法（例如微软拼音）时，向前 / 向后滚动盲文显示，会始终跳回原来输入光标位置的问题。(#12855)</target>
       </segment>
     </unit>
     <unit id="5d0277ca-f84c-4c95-bc8f-1a0e2a5f2499">
@@ -24341,7 +24341,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Espeak-ng has been updated to 1.51-dev commit `ab11439b18238b7a08b965d1d5a6ef31cbb05cbb`. (#12449, #12202, #12280, #12568)</source>
-        <target>将 Espeak-ng 更新至 1.51-dev commit `ab11439b18238b7a08b965d1d5a6ef31cbb05cbb`。(#12449, #12202, #12280, #12568)</target>
+        <target>将 Espeak-NG 更新至 1.51-dev commit `ab11439b18238b7a08b965d1d5a6ef31cbb05cbb`。(#12449, #12202, #12280, #12568)</target>
       </segment>
     </unit>
     <unit id="a5e83e4e-4dc4-47a5-bf61-a97e4b684fd2">
@@ -24648,7 +24648,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>There are updates to Unicode CLDR, mathematical symbols, and LibLouis.</source>
-        <target>此外还更新了以下三个本地数据库 Unicode CLDR（通用本地化数据存储库）、LibLouis（盲文表）以及腧穴符号。</target>
+        <target>此外还更新了以下三个本地数据库 Unicode CLDR（通用本地化数据存储库）、LibLouis（盲文表）以及数学符号。</target>
       </segment>
     </unit>
     <unit id="7a8f4f4b-d600-4168-9e5d-81d9452fd18a">
@@ -24657,7 +24657,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>As well as many bug fixes and improvements, including in Office, Visual Studio, and several languages.</source>
-        <target>一如既往的，包含许多 Bug 修复和改进，涵盖 Office、 Visual Studio 以及多语言显示等。</target>
+        <target>一如既往地，包含许多 Bug 修复和改进，涵盖 Office、 Visual Studio 以及多语言显示等。</target>
       </segment>
     </unit>
     <unit id="a6a90e8b-20ea-41e4-b9eb-91ac32ee3dad">
@@ -24816,7 +24816,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Added more mathematical symbols to the symbols dictionary. (#11467)</source>
-        <target>在符号词典中增加了更多的数学符号。（译者注：新增了众多腧穴符号，涵盖集合、逻辑、线性代数、几何和微积分等。）(#11467)</target>
+        <target>在符号词典中增加了更多的数学符号。（译者注：新增了众多数学符号，涵盖集合、逻辑、线性代数、几何和微积分等。）(#11467)</target>
       </segment>
     </unit>
     <unit id="c2569152-3871-4295-839e-e1508f1802ba">
@@ -25076,7 +25076,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>TextInfo.getTextInChunks no longer freezes when called on Rich Edit controls such as the NVDA log viewer. (#11613)</source>
-        <target>TextInfo.getTextInChunks 不再音于富文本控件调用时冻结（如日志查看器）。(#11613)</target>
+        <target>TextInfo.getTextInChunks 不再由于富文本控件调用时冻结（如日志查看器）。(#11613)</target>
       </segment>
     </unit>
     <unit id="9188053b-8c87-46d6-a0ad-1dbba6182fb4">
@@ -26210,7 +26210,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Added a command to toggle reporting of marked (highlighted) text; There is no default associated gesture. (#11807)</source>
-        <target>增加了一个用于切换是否读出“标记（高亮）”的命令，默认没有分配首饰。(#11807)</target>
+        <target>增加了一个用于切换是否读出“标记（高亮）”的命令，默认没有分配手势。(#11807)</target>
       </segment>
     </unit>
     <unit id="1e27a0e8-ebad-49d2-8d15-12a84ff8e8da">
@@ -26330,7 +26330,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>When reading with say all in browse mode, the find next and find previous commands do not stop reading anymore if Allow skim reading option is enabled; say all rather resumes from after the next or previous found term. (#11563)</source>
-        <target>在浏览模式中使用全文朗读时，，若启用了“在全文朗读模式下启用快捷键导航”选项，“查找下一个”和“查找上一个”命令不再打断朗读，而是从查找结果处继续向下执行全文朗读。(#11563)</target>
+        <target>在浏览模式中使用全文朗读时，若启用了“在全文朗读模式下启用快捷键导航”选项，“查找下一个”和“查找上一个”命令不再打断朗读，而是从查找结果处继续向下执行全文朗读。(#11563)</target>
       </segment>
     </unit>
     <unit id="e312bfb8-5543-4e62-939d-c45300e0d780">
@@ -26640,7 +26640,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Strong and emphasis tags in Internet Explorer can again be suppressed from being reported by turning off Report Emphasis in NVDA's Document Formatting settings. (#11808)</source>
-        <target>若关闭了 NVDA “文档格式”设置中的“强调”，则不会在错误的读出 Internet Explorer 中的“强调”和“高亮”标记。(#11808)</target>
+        <target>若关闭了 NVDA “文档格式”设置中的“强调”，则不会再错误地读出 Internet Explorer 中的“强调”和“高亮”标记。(#11808)</target>
       </segment>
     </unit>
     <unit id="04f229dc-ffb5-4b10-81db-3074f1b95d8e">
@@ -26848,7 +26848,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>You can now toggle NVDA's touchscreen support. An option has been added to the Touch Interaction panel of NVDA's settings. The default gesture is NVDA+control+alt+t. (#9682)</source>
-        <target>您可以切换 NVDA 的触摸屏支持。在 NVDA 的“输入首饰”的“触摸屏”分类下添加了一个选项。默认热键为 NVDA+control+alt+t。(#9682)</target>
+        <target>您可以切换 NVDA 的触摸屏支持。在 NVDA 的“输入手势”的“触摸屏”分类下添加了一个选项。默认热键为 NVDA+control+alt+t。(#9682)</target>
       </segment>
     </unit>
     <unit id="f7015abc-c070-4128-a808-0b8807907f85">
@@ -26898,7 +26898,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>New emulated system keyboard keys can be added from NVDA's Input gestures dialog. (#6060)</source>
-        <target>可以从 NVDA 的“输入首饰”对话框中添加新的模拟系统按键。(#6060)</target>
+        <target>可以从 NVDA 的“输入手势”对话框中添加新的模拟系统按键。(#6060)</target>
       </segment>
     </unit>
     <unit id="d809c425-2bf9-4164-a79f-aa214283105b">
@@ -27108,7 +27108,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>In the Input Gestures dialog, significantly improved performance while filtering. (#10307)</source>
-        <target>在“输入首饰”对话框中，显著提高了查找的性能。(#10307)</target>
+        <target>在“输入手势”对话框中，显著提高了查找的性能。(#10307)</target>
       </segment>
     </unit>
     <unit id="b9e6eb1b-7589-4ed5-b58a-0832954f0cd9">
@@ -27906,7 +27906,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>You can now perform right mouse clicks on touch devices by doing a one finger tap and hold. (#3886)</source>
-        <target>当前，您可以使用单指按下的首饰在触摸设备上单击鼠标右键。(#3886)</target>
+        <target>当前，您可以使用单指按下的手势在触摸设备上单击鼠标右键。(#3886)</target>
       </segment>
     </unit>
     <unit id="ba774011-491e-42bd-ba3b-a4c9a996cfaa">
@@ -28401,7 +28401,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>In Internet Explorer, Google Chrome and Mozilla Firefox, You can now navigate by article and grouping using quick navigation scripts. These scripts are unbound by default and can be assigned in the Input Gestures dialog when the dialog is opened from a browse mode document. (#9485, #9227)</source>
-        <target>在 Internet Explorer、Google Chrome 和 Mozilla Firefox 中，现在可以使用单件导航按“文章”和“分组”进行浏览。该功能默认未绑定快捷手势，您可以在“输入手势”对话框中进行配置。(#9227)</target>
+        <target>在 Internet Explorer、Google Chrome 和 Mozilla Firefox 中，现在可以使用单键导航按“文章”和“分组”进行浏览。该功能默认未绑定快捷手势，您可以在“输入手势”对话框中进行配置。(#9227)</target>
       </segment>
     </unit>
     <unit id="06a7b107-8bec-4885-b3ac-1a787af8b2d3">
@@ -28441,7 +28441,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Added a script to enable screen curtain (until next restart with one press, or always while NVDA is running with two presses), no default gesture is assigned.</source>
-        <target>新增用于开关黑屏的首饰设置（按一次临时开启黑屏，直至下次重启 NVDA 后恢复，连按两次开启黑屏，需手动关闭），注意：未分配默认手势。</target>
+        <target>新增用于开关黑屏的手势设置（按一次临时开启黑屏，直至下次重启 NVDA 后恢复，连按两次开启黑屏，需手动关闭），注意：未分配默认手势。</target>
       </segment>
     </unit>
     <unit id="d9af3b45-fbb5-4e05-a607-d22ac7e1c27e">
@@ -30109,7 +30109,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>In the Windows 10 May 2019 Update, NVDA no longer speaks many volume notifications if changing the volume with hardware buttons when File Explorer has focus. (#9466)</source>
-        <target>在 Windows 102019 年 5 月更新版中，聚焦于文件管理器，使用物理案件调整音量时，NVDA 将不再连续朗读音量调整提示。(#9466)</target>
+        <target>在 Windows 102019 年 5 月更新版中，聚焦于文件管理器，使用物理按键调整音量时，NVDA 将不再连续朗读音量调整提示。(#9466)</target>
       </segment>
     </unit>
     <unit id="eaf52d4f-95ff-411e-95e6-41447b0cbac6">
@@ -30199,7 +30199,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>The bumper keys now work correctly on Freedom Scientific braille displays. (#8849)</source>
-        <target>在 Freedom Scientific 系列点显器中，保险案件现在工作正常。(#8849)</target>
+        <target>在 Freedom Scientific 系列点显器中，保险按键现在工作正常。(#8849)</target>
       </segment>
     </unit>
     <unit id="2b1c569b-6752-4667-b1a4-60ef1f154000">
@@ -30219,7 +30219,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>HTCom can now be used with a Handy Tech Braille display in combination with NVDA. (#9691)</source>
-        <target>HTCom 现在可以合 Handy Tech 盲文点显器以即 NVDA 配合使用。(#9691)</target>
+        <target>HTCom 现在可以和 Handy Tech 盲文点显器以即 NVDA 配合使用。(#9691)</target>
       </segment>
     </unit>
     <unit id="7d6b488b-8386-4381-93e7-34688db53115">
@@ -32316,7 +32316,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>You can now toggle control, shift, alt, windows and NVDA from your braille keyboard and combine these modifiers with braille input (e.g. press control+s). (#7306)</source>
-        <target>您现在可以从盲文键盘切换控制，移位，替代，窗口和 NVDA，并将这些修饰符与盲文输入（例如按下 control+s）进行组合。(#7306)</target>
+        <target>您现在可以从盲文键盘切换Control，Shift，Alt，Windows和 NVDA键，并将这些修饰键与盲文输入（例如按下 control+s）进行组合。(#7306)</target>
       </segment>
     </unit>
     <unit id="1599252f-b9a1-45cc-a086-06ffb01f159a">
@@ -33462,7 +33462,7 @@ $(ID:efa13148-65e5-4484-85b1-9e57c61df3e3)
       </notes>
       <segment state="final">
         <source>Espeak-ng has been updated to 1.49.2, resolving some issues with producing release builds. (#7385, #7583)</source>
-        <target>Espeak-ng 已经更新到 1.49.2，解决了一些生成发布版本时产生的问题。(#7385，#7583)</target>
+        <target>Espeak-NG 已经更新到 1.49.2，解决了一些生成发布版本时产生的问题。(#7385，#7583)</target>
       </segment>
     </unit>
     <unit id="80597d2d-040e-4984-aa80-7c2636bd7d2f">

--- a/Translation/user_docs/userGuide.xliff
+++ b/Translation/user_docs/userGuide.xliff
@@ -6218,7 +6218,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>This applies to both original and modified copies of this software, plus any derivative works.</source>
-        <target>此槼则适用于原始发布的软件或任何以此软件修改之后发布的作品，以及所有采用此软件内的程序和源代码所衍生的作品。</target>
+        <target>此规则适用于原始发布的软件或任何以此软件修改之后发布的作品，以及所有采用此软件内的程序和源代码所衍生的作品。</target>
       </segment>
     </unit>
     <unit id="69a3880d-d533-4eba-8c8a-93f210208e94">
@@ -6543,7 +6543,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>The year and version changes between updates to reflect the current release.</source>
-        <target>年份和表示版本信息的其它数字会随更新而改变，以反应最近发布的版本。</target>
+        <target>年份和表示版本信息的其他数字会随更新而改变，以反应最近发布的版本。</target>
       </segment>
     </unit>
     <unit id="f5455ce9-c9c9-4349-8e71-c248bd6cfcff">
@@ -6666,7 +6666,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>The main thing NVDA needs to know is the folder to setup the portable copy in.</source>
-        <target>重要的事情是 NVDA 需要知道创建便携版本的文件夹。</target>
+        <target>关键在于，您需要为NVDA 指定创建便携版本的文件夹。</target>
       </segment>
     </unit>
     <unit id="985b8513-61a6-4cc7-b58e-22ff1d1a4d4f">
@@ -6958,7 +6958,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>If desired, press `downArrow` to choose "Laptop" keyboard layout to reassign number pad functions to other keys.</source>
-        <target>如果愿意，可以按`下光标`选择“笔记本”键盘配置，将数字键盘的功能分配到其它按键上。</target>
+        <target>如果愿意，可以按`下光标`选择“笔记本”键盘配置，将数字键盘的功能分配到其他按键上。</target>
       </segment>
     </unit>
     <unit id="8c03482e-7f30-4a5f-a188-da0235b8dd06">
@@ -7014,7 +7014,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Use `tab` and `spaceBar` to adjust the other options on this screen.</source>
-        <target>用 `Tab` 和`空格`对屏幕上的其它选项进行调整。</target>
+        <target>用 `Tab` 和`空格`对屏幕上的其他选项进行调整。</target>
       </segment>
     </unit>
     <unit id="0b15b2db-4a71-4edb-b5e2-cbab27e4ccb2">
@@ -7275,7 +7275,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Read current line |`NVDA+upArrow` |`NVDA+l` |Reads the line. Pressing twice spells the line. Pressing three times spells the line using character descriptions (Alpha, Bravo, Charlie, etc)</source>
-        <target>朗读当前行 | `NVDA+上光标` | `NVDA+L` | 朗读当前行。连按两次逐字朗读。连按三次逐字解释（如 Alpha，Bravo，Charlie 等。）</target>
+        <target>朗读当前行 | `NVDA+上光标` | `NVDA+L` | 朗读当前行。连按两次逐字朗读。连按三次逐字解释（如 Alpha，Bravo，Charlie 等）。</target>
       </segment>
     </unit>
     <unit id="01d3bac2-112e-48ce-b082-4259aa5a3d78">
@@ -7297,7 +7297,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Read clipboard text |`NVDA+c` |`NVDA+c` |Reads any text on the clipboard. Pressing twice will spell the information. Pressing three times will spell it using character description</source>
-        <target>朗读剪贴板文本 | `NVDA+C` | `NVDA+C` | 朗读剪贴板中的任何文本。连按两次逐字朗读，连按三次逐字解释</target>
+        <target>朗读剪贴板文本 | `NVDA+C` | `NVDA+C` | 朗读剪贴板中的文本。连按两次逐字朗读，连按三次逐字解释</target>
       </segment>
     </unit>
     <unit id="c4c7d16e-ae6a-440c-ae16-9fd7f68c29c6">
@@ -7308,7 +7308,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Reporting location and other information</source>
-        <target>朗读位置和其它信息</target>
+        <target>朗读位置和其他信息</target>
       </segment>
     </unit>
     <unit id="2b8a76c9-22b0-4fac-883e-5df827bd9f09">
@@ -7462,7 +7462,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Speak command keys |`NVDA+4` |`NVDA+4` |When enabled, NVDA will announce all non-character keys you type on the keyboard. This includes key combinations such as control plus another letter.</source>
-        <target>朗读命令键 | `NVDA+4` | `NVDA+4` | 如果启用，NVDA 会读出您在键盘上键入的所有飞字符按键。也包括组合键，例如 Ctrl 加其他字母。</target>
+        <target>朗读命令键 | `NVDA+4` | `NVDA+4` | 如果启用，NVDA 会读出您在键盘上键入的所有非字符按键。也包括组合键，例如 Ctrl 加其他字母。</target>
       </segment>
     </unit>
     <unit id="08d56fc9-179e-47ec-a87a-d78148fac9c5">
@@ -7473,7 +7473,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Enable mouse tracking |`NVDA+m` |`NVDA+m` |When enabled, NVDA will announce the text currently under the mouse pointer, as you move it around the screen. This allows you to find things on the screen, by physically moving the mouse, rather than trying to find them through object navigation.</source>
-        <target>启用鼠标导航 | `NVDA+m` | `NVDA+m` | 如果启用，当您在屏幕上移动鼠标时，NVDA 会朗读指针当前所指的文本。这允许您确实通过移动鼠标来寻找屏幕上的东西，而不是尝试通过对象导航来寻找它们。</target>
+        <target>启用鼠标导航 | `NVDA+m` | `NVDA+m` | 如果启用，当您在屏幕上移动鼠标时，NVDA 会朗读指针当前所指的文本。也就是说，除了使用对象导航以外您还可以直接通过移动鼠标来寻找屏幕上的内容。</target>
       </segment>
     </unit>
     <unit id="6ea752d8-0e5b-428a-bb3e-c0a478e03666">
@@ -7747,7 +7747,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Settings, and other options, are available via NVDA's menu.</source>
-        <target>设置和其它选项都可以通过 NVDA 菜单来使用。</target>
+        <target>设置和其他选项都可以通过 NVDA 菜单来使用。</target>
       </segment>
     </unit>
     <unit id="43aaf573-6b50-403e-a07c-85327e5d884d">
@@ -7774,7 +7774,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Many settings screens have keystrokes to open them directly, such as `NVDA+control+s` for synthesizer, or `NVDA+control+v` for other voice options.</source>
-        <target>许多 NVDA 设置界面都有直接打开它们的按键，例如 `NVDA+Ctrl+S` 打开合成器对话框，`NVDA+Ctrl+V` 可以打开其它语音设置的界面。</target>
+        <target>许多 NVDA 设置界面都有直接打开它们的按键，例如 `NVDA+Ctrl+S` 打开合成器对话框，`NVDA+Ctrl+V` 可以打开其他语音设置的界面。</target>
       </segment>
     </unit>
     <unit id="0de12c34-a59f-4e59-ad3b-157ea59029df">
@@ -8260,7 +8260,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Disabling an add-on stops NVDA from loading it, but leaves it installed.</source>
-        <target>禁用某插件后 NVDA 启动时就不加载该插件了，但插件仍然处于安装状态。</target>
+        <target>禁用某插件后 NVDA 启动时将不会加载该插件，但插件仍然处于安装状态。</target>
       </segment>
     </unit>
     <unit id="3ff567de-1997-428d-bca9-778d1f50b179">
@@ -8491,7 +8491,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>There is also more comprehensive Training Material available in the [NV Access Shop](https://www.nvaccess.org/shop).</source>
-        <target>[NV Access Shop](https://www.nvaccess.org/shop) 有更全更多的培训资料可用。</target>
+        <target>[NV Access Shop](https://www.nvaccess.org/shop) 有更全面的培训资料可供使用。</target>
       </segment>
     </unit>
     <unit id="39c70522-043d-4ff7-afae-c3d8c28b0a6e">
@@ -8557,7 +8557,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Other modules, and the discounted [NVDA Productivity Bundle](https://www.nvaccess.org/product/nvda-productivity-bundle/), are available in the [NV Access Shop](https://www.nvaccess.org/shop/).</source>
-        <target>其它模块和优惠活动：[NVDA Productivity Bundle](https://www.nvaccess.org/product/nvda-productivity-bundle/)，[NV Access Shop](https://www.nvaccess.org/shop)。</target>
+        <target>其他模块和优惠活动：[NVDA Productivity Bundle](https://www.nvaccess.org/product/nvda-productivity-bundle/)，[NV Access Shop](https://www.nvaccess.org/shop)。</target>
       </segment>
     </unit>
     <unit id="9af3c950-afba-4bdc-9310-731d17ec11a6">
@@ -8772,7 +8772,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>This also includes User Account Control and [other secure screens](#SecureScreens).</source>
-        <target>这也包括用户账户控制对话框和[其它安全界面](#SecureScreens)。</target>
+        <target>这也包括用户账户控制对话框和[其他安全界面](#SecureScreens)。</target>
       </segment>
     </unit>
     <unit id="9027d672-f478-4234-b084-a537a4d65d0e">
@@ -8839,7 +8839,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>This will not copy the configuration for any other users of this system nor to the system configuration for use during Windows sign-in and [other secure screens](#SecureScreens).</source>
-        <target>此选项不会为此系统上的其他用户拷贝配置，也不会将配置应用于 Windows 欢迎界面和[其它安全界面](#SecureScreens)。</target>
+        <target>此选项不会为此系统上的其他用户拷贝配置，也不会将配置应用于 Windows 欢迎界面和[其他安全界面](#SecureScreens)。</target>
       </segment>
     </unit>
     <unit id="7a2c8f35-4e70-4180-a6cd-e1c4034d195a">
@@ -8895,7 +8895,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>This can be a directory on your hard drive or a location on a USB thumb drive or other portable media.</source>
-        <target>可以是您的硬盘驱动器中的一个目录，U 盘的某一位置，或其它便携媒体。</target>
+        <target>可以是您的硬盘驱动器中的一个目录，U 盘的某一位置，或其他便携媒体。</target>
       </segment>
     </unit>
     <unit id="21faeece-4886-4177-bf58-a38def299b29">
@@ -8996,7 +8996,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>If you want to take NVDA with you on a USB thumb drive or other writable media, then you should choose to create a portable copy.</source>
-        <target>如果您想将 NVDA 放在 U 盘或其它便携媒体中随身携带，您可以选择创建一个便携版。</target>
+        <target>如果您想将 NVDA 放在 U 盘或其他便携媒体中随身携带，您可以选择创建一个便携版。</target>
       </segment>
     </unit>
     <unit id="97a09c6b-3a11-4cf2-9d35-51025ca2a504">
@@ -9088,7 +9088,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>The inability to interact with applications running with administrative privileges, unless of course NVDA itself has been run also with these privileges (not recommended). Examples include:</source>
-        <target>无法与使用管理员权限运行的应用程序进行交互，当然，除非 NVDA 本身也已经运行在管理员权限之下（不推荐）。比如：</target>
+        <target>无法与使用管理员权限运行的应用程序进行交互，当然，除非 NVDA 本身也已经运行在管理员权限下（不推荐）。比如：</target>
       </segment>
     </unit>
     <unit id="238e90b9-21bd-4251-b63c-13c82e36b046">
@@ -9225,7 +9225,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>For installed copies, NVDA stores the configuration in the roaming application data folder of the current user by default (e.g. "`C:\Users\&lt;user&gt;\AppData\Roaming`").</source>
-        <target>NVDA 安装版的配置在“漫游”应用程序配置文件夹（比如 "`C:\Users\&lt;用户名&gt;\AppData\Roaming`"）。</target>
+        <target>NVDA 安装版的配置在 Windows 系统的“漫游”应用数据文件夹中（比如 "`C:\Users\&lt;用户名&gt;\AppData\Roaming`"）。</target>
       </segment>
     </unit>
     <unit id="b731e377-9666-442b-ab38-13a373574f87">
@@ -9588,7 +9588,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Therefore, actions that can be performed normally without NVDA will not work.</source>
-        <target>因而，所有在运行 NVDA 之前通常能使用的动作/首饰都将暂时不可用。</target>
+        <target>因而，所有在运行 NVDA 之前通常能使用的动作/手势都将暂时不可用。</target>
       </segment>
     </unit>
     <unit id="42992d3a-1e68-4d1c-a6c4-9f12e56bf279">
@@ -9702,7 +9702,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Tapping once with one finger is simply known as a tap.</source>
-        <target>用一个手指轻击屏幕一次仅被简单的识别为一次点击。</target>
+        <target>用一个手指轻击屏幕一次仅被识别为一次单击。</target>
       </segment>
     </unit>
     <unit id="fa038863-bf8d-4c6d-bc5f-b8b29c4c05b3">
@@ -10154,7 +10154,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Toggle Input Help Mode |NVDA+1 |NVDA+1 |none |Pressing any key in this mode will report the key, and the description of any NVDA command associated with it</source>
-        <target>切换输入帮助模式 | NVDA+1 | NVDA+1 | 无 | 在此模式之下，按下任何按键都将读出其名称和与其关联的 NVDA 命令</target>
+        <target>切换输入帮助模式 | NVDA+1 | NVDA+1 | 无 | 在此模式下，按下任何按键都将读出其名称和与其关联的 NVDA 命令</target>
       </segment>
     </unit>
     <unit id="d38605d3-3e0e-4be8-bea1-2fbf2f8efbdb">
@@ -11398,7 +11398,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Report current line in review |numpad8 |NVDA+shift+. |none |Announces the current line of text where the review cursor is positioned. Pressing twice spells the line. Pressing three times spells the line using character descriptions.</source>
-        <target>读出查看文本的当前行 | `数字键盘8` | `NVDA+Shift+.` | 无 | 读出查看光标所在位置的文本的当前航，连按两次逐字朗读，连按三次逐字解释。</target>
+        <target>读出查看文本的当前行 | `数字键盘8` | `NVDA+Shift+.` | 无 | 读出查看光标所在位置的文本的当前行，连按两次逐字朗读，连按三次逐字解释。</target>
       </segment>
     </unit>
     <unit id="0f4a8091-c712-4667-b7f4-32a374c4636f">
@@ -13985,7 +13985,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Although it is generally recommended to use one of the newer NVDA add-ons to support math in NVDA, in certain limited scenarios MathPlayer may still be a more suitable choice.</source>
-        <target>尽管通常建议使用较新的插件来支持 NVDA 中的数学，但在某些有限的情况下，MathPlayer 可能仍然是更合适的选择。</target>
+        <target>尽管通常建议使用较新的插件来支持 NVDA 中的数学，但在某些受限情况下，MathPlayer 可能仍然是更合适的选择。</target>
       </segment>
     </unit>
     <unit id="297c862b-fad5-4e65-b9c2-aaf38772995e">
@@ -15133,7 +15133,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Note that translation can only reflect the braille word you are typing and cannot consider existing text.</source>
-        <target>值得注意的是:盲文转译仅可翻译您输入的盲文，而非现有的文本。</target>
+        <target>值得注意的是，盲文转译仅可翻译您输入的盲文，而非现有的文本。</target>
       </segment>
     </unit>
     <unit id="33566542-af77-42d7-8541-71a0d19ad3f1">
@@ -15270,7 +15270,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>For example, to produce control+f, use the "Toggle control key" command and then type an f,</source>
-        <target>例如，要按 `Ctrl+F` ，请使用“模拟按下货放开 `Ctrl`”命令，然后键入 `F`，</target>
+        <target>例如，要按 `Ctrl+F` ，请使用“模拟按下或放开 `Ctrl`”命令，然后键入 `F`，</target>
       </segment>
     </unit>
     <unit id="2fe5b5c9-723c-4756-ab44-207ef3e7fc51">
@@ -15279,7 +15279,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>and to input control+alt+t, use either the "Toggle control key" and "Toggle alt key" commands, in either order, or the "Toggle control and alt keys" command, followed by typing a t.</source>
-        <target>要按 `Ctrl+Alt+T`，请按任意顺序执行“模拟按下货放开 `Ctrl`”、“模拟按下货放开 `Alt`”或“模拟按下货放开 `Ctrl+Alt`”然后键入字母“T”。</target>
+        <target>要按 `Ctrl+Alt+T`，请按任意顺序执行“模拟按下或放开 `Ctrl`”、“模拟按下或放开 `Alt`”或“模拟按下或放开 `Ctrl+Alt`”然后键入字母“T”。</target>
       </segment>
     </unit>
     <unit id="66ce438d-72f5-41b7-9499-dcbc4231540f">
@@ -16315,7 +16315,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>In Microsoft 2016, 365 and newer, the classic comments in Microsoft Excel have been renamed to "notes".</source>
-        <target>在英文版 Microsoft 2016、365 和更高版本中，Microsoft Excel 中的注释“Comment”已重命名为“Notes”，与新的批注区分，中文版不变。</target>
+        <target>在英文版 Microsoft 2016、365 和更高版本中，Microsoft Excel 中的注释“Comment”已重命名为“Notes”，与新的批注区分（中文版该术语保持不变）。</target>
       </segment>
     </unit>
     <unit id="3e3cd3a1-acb7-443b-aa2f-bf6c88467ff1">
@@ -16863,7 +16863,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>You can add a note regarding a word or passage of text.</source>
-        <target>您可以添加关于文字的单词或段落的注释。</target>
+        <target>您可以为单词或段落添加注释。</target>
       </segment>
     </unit>
     <unit id="99f1217e-11c4-44e2-aaa1-9571bcd386ae">
@@ -17429,7 +17429,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>When the confirmation dialog appears, select "restart now" or "restart later" if you wish to use the new language now or at a later time, respectively. If "restart later" is selected, the configuration must be saved (either manually or using the save on exit functionality).</source>
-        <target>出现确认对话框时，如果您希望现在或稍后使用新语言，请选择“立即重启”或“稍后重启”。如果选择“稍后重启”，则必须保存配置（手动保存或打开退出时保存配置的功能）。</target>
+        <target>出现确认对话框时，如果您希望现在或稍后使用新语言，请选择“立即重启”或“稍后重启”。如果选择“稍后重启”，则必须保存配置（手动保存或启用“退出时保存设置”的功能）。</target>
       </segment>
     </unit>
     <unit id="b1782921-9b3f-4f20-a643-b7386e3c1701">
@@ -18746,7 +18746,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>If you find that NVDA is reading punctuation in the wrong language for a particular synthesizer or voice, you may wish to turn this off to force NVDA to use its global language setting instead.</source>
-        <target>如果您发现 NVDA 在使用特定的合成器或声音读出某标点时使用了错误的语言，您可能希望把它关闭并强制 NVDA 使用其自身的本地设置来代替语音语言。</target>
+        <target>如果您发现 NVDA 在使用特定的合成器或声音读出某标点时使用了错误的语言，您可能希望将其关闭并强制 NVDA 使用其自身的本地设置来代替语音语言。</target>
       </segment>
     </unit>
     <unit id="b32b47e9-75ae-464e-a49c-6c304dad609a">
@@ -20189,7 +20189,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>To toggle move system caret when routing review cursor from anywhere, please assign a custom gesture using the [Input Gestures dialog](#InputGestures).</source>
-        <target>如需随时切换“移动查看光标时移动系统光标”模式，请在[按键与首饰](#InputGestures)中分配一个快捷键。</target>
+        <target>如需随时切换“移动查看光标时移动系统光标”模式，请在[按键与手势](#InputGestures)中分配一个快捷键。</target>
       </segment>
     </unit>
     <unit id="0fb5939a-9b15-4e4f-b08f-a42393f13419">
@@ -22559,7 +22559,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>When enabled, a warning beep will be heard if a letter is typed with the shift key while Caps Lock is on.</source>
-        <target>如果启用，在大写锁定建打开时使用 Shift 键进行小写字母输入，您会听到一个警告提示音。</target>
+        <target>如果启用，在大写锁定键打开时使用 Shift 键进行小写字母输入，您会听到一个警告提示音。</target>
       </segment>
     </unit>
     <unit id="79060ef8-598a-453b-915f-33e43ba510ff">
@@ -22568,7 +22568,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Generally, typing shifted letters with Caps Lock is unintentional and is usually due to not realizing that Caps Lock is enabled.</source>
-        <target>一般来说，使用大写锁定建输入转译字符是无意识的，通常是由于未能意识到大写锁定已被启用。</target>
+        <target>一般来说，使用大写锁定键输入转译字符是无意识的，通常是由于未能意识到大写锁定已被启用。</target>
       </segment>
     </unit>
     <unit id="240adbaf-71b4-4baa-be65-6fe68ce3c963">
@@ -22606,7 +22606,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>When enabled, NVDA will announce all non-character keys you type on the keyboard. This includes key combinations such as control plus another letter.</source>
-        <target>如果启用，NVDA 将读出您在键盘上键入的所有飞字符按键，这也包括组合键，例如 Ctrl 加其他字母。</target>
+        <target>如果启用，NVDA 将读出您在键盘上键入的所有非字符按键，这也包括组合键，例如 Ctrl 加其他字母。</target>
       </segment>
     </unit>
     <unit id="290688f5-e42e-4e2a-9ed9-906598c0fe7f">
@@ -23363,7 +23363,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Many Windows and controls show a small message (or tooltip) when you move the mouse pointer over them, or sometimes when you move the focus to them.</source>
-        <target>当您的鼠标指针经过某些窗口和对象，或有时把焦点放在他们上面时，这些窗口或控件都会显示短消息（或称工具提示）。</target>
+        <target>当您的鼠标指针经过某些窗口和对象，或者此类对象获得焦点时，这些窗口或控件会显示短消息（或称工具提示）。</target>
       </segment>
     </unit>
     <unit id="d25ff2d7-8b88-4403-b3fe-e98c7620a8b4">
@@ -24198,7 +24198,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>This option affects how NVDA handles tables used purely for layout purposes.</source>
-        <target>此选项用于控制仅用作布局的列表的获取。</target>
+        <target>此选项用于控制 NVDA 如何处理仅用于页面布局的表格。</target>
       </segment>
     </unit>
     <unit id="2d9e6432-7411-4fe7-90b8-ba5af9ef8033">
@@ -24379,7 +24379,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>As an example, if enabled and the letter j was pressed, it would be trapped from reaching the document, even though it is not a quick navigation command nor is it likely to be a command in the application itself.</source>
-        <target>举一个例子，如果启用，当您按下字母“j”后，它会被拦截，也就是这一按键既不会作为 NVDA 的跳转热键，也不会作为程序自身的命令（译者注：就上面的例子来说，假设我们现在聚焦在 word 文档里，当按 j 的时候，他不会跳转文档，也不会当成字母 j 输入到文档）。</target>
+        <target>举一个例子，如果启用，当您按下字母“j”后，它会被拦截，也就是这一按键既不会作为 NVDA 的跳转热键，也不会作为程序自身的命令（译者注：就上面的例子来说，假设我们现在聚焦在 word 文档里，当按 j 的时候，它不会跳转文档，也不会当成字母 j 输入到文档）。</target>
       </segment>
     </unit>
     <unit id="5b169a35-7d7b-4409-93a6-27660bcf9fd9">
@@ -26674,7 +26674,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>This applies to documents in Microsoft word itself, plus messages in Microsoft Outlook.</source>
-        <target>此选项适用于 Microsoft Word 文档，以及 Microsoft Outlook 中的消息控件。</target>
+        <target>此选项适用于 Microsoft Word 文档，以及 Microsoft Outlook 中的消息区域。</target>
       </segment>
     </unit>
     <unit id="625325c5-df89-4943-90a7-e8bcfca611c9">
@@ -27944,7 +27944,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>The speech dictionaries menu (found in the Preferences menu) contains dialogs that allow you to manage the way NVDA pronounces particular words or phrases.</source>
-        <target>“语音字典”对话框，可用来为特定词语或者短语指定特殊的朗读方法，他可以再“选项”菜单下的“语音字典”找到。</target>
+        <target>“语音字典”对话框，可用来为特定词语或者短语指定特殊的朗读方法，它可以在“选项”菜单下的“语音字典”找到。</target>
       </segment>
     </unit>
     <unit id="dc0e68cd-a242-475e-8cf0-7074d523231c">
@@ -28472,7 +28472,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>You can filter them by entering one or more words from the command's name into the Filter by edit box in any order.</source>
-        <target>您可以通过在“过滤字符”编辑框无序的输入命令的一个或多个单词来对他们进行过滤。</target>
+        <target>您可以通过在“查找”编辑框中输入命令的部分文本进行查找。</target>
       </segment>
     </unit>
     <unit id="ff639816-4f11-43eb-bfe5-c1b5240a7798">
@@ -28481,7 +28481,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Any gestures associated with a command are listed beneath the command.</source>
-        <target>任何与命令相关的按键或手势都会被列举在该命令之下。</target>
+        <target>任何与命令相关的按键或手势都会被列举在该命令下。</target>
       </segment>
     </unit>
     <unit id="d5170a1a-8f6e-4dd5-b0f3-6301714f25c0">
@@ -29304,7 +29304,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Installed versions of NVDA store all settings and add-ons in a special NVDA directory located in your Windows user profile.</source>
-        <target>安装版本的 NVDA 的所有插件和配置文件都被放在您的 Windows 用户配置的文件的 NVDA 目录之下。</target>
+        <target>安装版本的 NVDA 的所有插件和配置文件都放在您的 Windows 用户配置的文件的 NVDA 目录下。</target>
       </segment>
     </unit>
     <unit id="1416b140-f2cb-4da1-baab-8d0e1d236203">
@@ -30710,7 +30710,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Just because an add-on is available in the NVDA Add-on Store, does not mean that it has been approved or vetted by NV Access or anyone else.</source>
-        <target>尽管 NVDA 插件商店中提供了某款插件，并不意味着该插件已获得 NV Access 或其他任何人的批准或审查。</target>
+        <target>虽然 NVDA 插件商店中提供了某款插件，但这并不意味着该插件已获得 NV Access 或其他任何人的批准或审查。</target>
       </segment>
     </unit>
     <unit id="07d2d518-fbed-4eaa-9433-cc0b03bbf34a">
@@ -31479,7 +31479,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>To enable the speech viewer, check the "Speech Viewer" menu item under Tools in the NVDA menu.</source>
-        <target>要想起用朗读查看器，可以再 NVDA 的“工具”菜单选中。</target>
+        <target>要想启用朗读查看器，可以在 NVDA 的“工具”菜单选中。</target>
       </segment>
     </unit>
     <unit id="edcfc4bf-3254-468f-a891-44229bf232ba">
@@ -36141,7 +36141,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>You can find more information about the displays on their [Demo and Driver Download page](https://en.seika-braille.com/down/index.html).</source>
-        <target>您可在其[演示和驱动程序下载](https://en.seika-braille.com/down/index.html)页面上找到有关点显器的更多信息。</target>
+        <target>您可在制造商的[演示和驱动程序下载](https://en.seika-braille.com/down/index.html)页面上找到有关点显器的更多信息。</target>
       </segment>
     </unit>
     <unit id="fa4bff7c-bbf1-4eb9-9676-b0f34de5b080">
@@ -39498,7 +39498,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Of the two keys placed like a space bar, the left key is corresponding to the backspace key and the right key to the space key.</source>
-        <target>像空格键一样放置的两个按键中，左键对应退格键，右键对应空格键。</target>
+        <target>这两个按键的放置方式类似空格键，其中左侧的按键对应退格键，右侧的按键对应空格键。</target>
       </segment>
     </unit>
     <unit id="01bf6633-fe8a-4d12-8c65-248d212e900d">
@@ -43490,7 +43490,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>These values are stored in the registry under one of the following keys:</source>
-        <target>配置信息保存在注册表的这些键值内:</target>
+        <target>配置信息保存在注册表的这些键值内：</target>
       </segment>
     </unit>
     <unit id="93da3bfa-4115-437a-b0ea-cb2f8afe13d2">

--- a/Translation/user_docs/userGuide.xliff
+++ b/Translation/user_docs/userGuide.xliff
@@ -28154,7 +28154,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>A regular expression is a pattern containing special symbols that allow you to match on more than one character at a time, or match on just numbers, or just letters, as a few examples.</source>
-        <target>“正则表达式”是一个包含特殊符号的匹配模板，允许您在一次匹配超过一个字符串，仅匹配数字或仅匹配字母等等，这些仅仅是一些例子罢了。</target>
+        <target>“正则表达式”是一个包含特殊符号的匹配模板，允许您同时匹配多个字符，仅匹配数字或仅匹配字母等等。</target>
       </segment>
     </unit>
     <unit id="d5b89b40-aef6-4231-906b-f3a40ce2c3d6">
@@ -28674,7 +28674,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>If you ever make a mistake with your settings and need to revert back to the saved settings, choose the "revert to saved configuration" item in the NVDA menu.</source>
-        <target>如果您曾做了一个错误的修改，希望恢复到保存的设置，在 NVDA 菜单选择“重新应用以保存的设置”菜单项目。</target>
+        <target>如果您做了一个错误的修改，希望恢复到上次保存的设置，在 NVDA 菜单选择“重新应用已保存的配置”菜单项目。</target>
       </segment>
     </unit>
     <unit id="9b202611-c256-4655-8b23-b4b9df5e5957">
@@ -29358,7 +29358,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>To change NVDA's configuration during sign-in or on UAC screens, configure NVDA as you wish while signed into Windows, save the configuration, and then press the "use currently saved settings during sign-in and on secure screens" button in the General category of the [NVDA Settings](#NVDASettings) dialog.</source>
-        <target>要想更改 NVDA 在欢迎屏幕和 UAC 屏幕上的配置，您需要在登录 Windows 后保存配置，然后转到 “[NVDA 设置](#NVDASettings)”中的“常规”设置对话框，点击“应用以保存的配置到欢迎界面和其他安全界面”按钮。</target>
+        <target>要想更改 NVDA 在欢迎屏幕和 UAC 屏幕上的配置，您需要在登录 Windows 后保存配置，然后转到 “[NVDA 设置](#NVDASettings)”中的“常规”设置对话框，点击“应用已保存的配置到欢迎界面和其他安全界面”按钮。</target>
       </segment>
     </unit>
     <unit id="14218f5c-7b9c-4029-a56c-183c9ea41e94">
@@ -41323,7 +41323,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
       </notes>
       <segment state="final">
         <source>Revert configuration |`prefload` (restore preferences from disk)</source>
-        <target>重新应用以保存的设置 |`prefload` (restore preferences from disk)</target>
+        <target>重新应用已保存的配置 |`prefload` (restore preferences from disk)</target>
       </segment>
     </unit>
     <unit id="85577197-1590-41b7-a79f-8a8b9c71fcdd">


### PR DESCRIPTION
例如‘首饰’和‘手势’、‘案件’和‘按键’，修复了一些用户指南中一些不通顺的表达。
/gemini summary
